### PR TITLE
FIX: Make FMM Generic over Floating Point Types

### DIFF
--- a/field/src/fft.rs
+++ b/field/src/fft.rs
@@ -3,7 +3,6 @@ use std::any::{Any, TypeId};
 
 use cauchy::Scalar;
 use fftw::{plan::*, types::*};
-use num::Float;
 use rayon::prelude::*;
 
 use rlst::dense::{

--- a/field/src/fft.rs
+++ b/field/src/fft.rs
@@ -3,7 +3,7 @@ use fftw::{plan::*, types::*};
 use num::Complex;
 use rayon::prelude::*;
 
-use crate::types::{FftMatrix, FftMatrixc32, FftMatrixc64, FftMatrixf32, FftMatrixf64};
+use crate::types::{FftMatrixc32, FftMatrixc64, FftMatrixf32, FftMatrixf64};
 use rlst::dense::RawAccessMut;
 
 pub trait Fft<DtypeReal, DtypeCplx>

--- a/field/src/fft.rs
+++ b/field/src/fft.rs
@@ -1,294 +1,158 @@
 //! Wrappers for FFTW functions, including multithreaded implementations.
-use std::any::{Any, TypeId};
-
-use cauchy::Scalar;
 use fftw::{plan::*, types::*};
+use num::Complex;
 use rayon::prelude::*;
 
-use rlst::{
-    common::traits::Eval,
-    dense::{
-        base_matrix::BaseMatrix, data_container::VectorContainer, matrix::Matrix, rlst_pointer_mat,
-        traits::*, Dynamic,
-    },
-};
+use crate::types::{FftMatrix, FftMatrixc32, FftMatrixc64, FftMatrixf32, FftMatrixf64};
+use rlst::dense::RawAccessMut;
 
-/// Type alias for real coefficients for into FFTW wrappers
-pub type FftMatrixf64 = Matrix<f64, BaseMatrix<f64, VectorContainer<f64>, Dynamic>, Dynamic>;
-
-/// Type alias for real coefficients for into FFTW wrappers
-pub type FftMatrixf32 = Matrix<f32, BaseMatrix<f32, VectorContainer<f32>, Dynamic>, Dynamic>;
-
-/// Type alias for real coefficients for into FFTW wrappers
-pub type FftMatrix<T> = Matrix<T, BaseMatrix<T, VectorContainer<T>, Dynamic>, Dynamic>;
-
-/// Type alias for complex coefficients for FFTW wrappers
-pub type FftMatrixc64 = Matrix<c64, BaseMatrix<c64, VectorContainer<c64>, Dynamic>, Dynamic>;
-
-/// Type alias for complex coefficients for FFTW wrappers
-pub type FftMatrixc32 = Matrix<c32, BaseMatrix<c32, VectorContainer<c32>, Dynamic>, Dynamic>;
-
-/// Type alias for complex coefficients for FFTW wrappers
-pub type FftMatrixc<T> = Matrix<T, BaseMatrix<T, VectorContainer<T>, Dynamic>, Dynamic>;
-
-/// Compute a Real FFT of an input slice corresponding to a 3D array stored in column major format, specified by `shape` using the FFTW library.
-///
-/// # Arguments
-/// * `input` - Input slice of real data, corresponding to a 3D array stored in column major order.
-/// * `output` - Output slice.
-/// * `shape` - Shape of input data.
-pub fn rfft3_fftw64(input: &mut [f64], output: &mut [c64], shape: &[usize]) {
-    assert!(shape.len() == 3);
-    let plan: R2CPlan64 = R2CPlan::aligned(shape, Flag::MEASURE).unwrap();
-    let _ = plan.r2c(input, output);
-}
-
-/// Compute a Real FFT of an input slice corresponding to a 3D array stored in column major format, specified by `shape` using the FFTW library.
-///
-/// # Arguments
-/// * `input` - Input slice of real data, corresponding to a 3D array stored in column major order.
-/// * `output` - Output slice.
-/// * `shape` - Shape of input data.
-pub fn rfft3_fftw32(input: &mut [f32], output: &mut [c32], shape: &[usize]) {
-    assert!(shape.len() == 3);
-    let plan: R2CPlan32 = R2CPlan::aligned(shape, Flag::MEASURE).unwrap();
-    let _ = plan.r2c(input, output);
-}
-
-pub fn rfft3_fftw<R, C>(input: &mut [R::Real], output: &mut [C::Complex], shape: &[usize])
+pub trait Fft<DtypeReal, DtypeCplx>
 where
-    R: Default + Scalar<Real = R> + Any,
-    C: Default + Scalar<Complex = C> + Any,
+    Self: Sized,
 {
-    if TypeId::of::<R>() == TypeId::of::<f32>() && TypeId::of::<C>() == TypeId::of::<c32>() {
-        let input_f32 =
-            unsafe { std::slice::from_raw_parts_mut(input.as_mut_ptr() as *mut f32, input.len()) };
-        let output_c32 = unsafe {
-            std::slice::from_raw_parts_mut(output.as_mut_ptr() as *mut c32, output.len())
-        };
-        rfft3_fftw32(input_f32, output_c32, shape);
-    } else if TypeId::of::<R>() == TypeId::of::<f64>() && TypeId::of::<C>() == TypeId::of::<c64>() {
-        let input_f64 =
-            unsafe { std::slice::from_raw_parts_mut(input.as_mut_ptr() as *mut f64, input.len()) };
-        let output_c64 = unsafe {
-            std::slice::from_raw_parts_mut(output.as_mut_ptr() as *mut c64, output.len())
-        };
-        rfft3_fftw64(input_f64, output_c64, shape);
+    /// Compute a Real FFT over a rlst matrix which stores data corresponding to multiple 3 dimensional arrays of shape `shape`, stored in column major order.
+    /// This function is multithreaded, and uses the FFTW library.
+    ///
+    /// # Arguments
+    /// * `input` - Input slice of real data, corresponding to a 3D array stored in column major order.
+    /// * `output` - Output slice.
+    /// * `shape` - Shape of input data.
+    fn rfft3_fftw_par_vec(input: &mut DtypeReal, output: &mut DtypeCplx, shape: &[usize]);
+
+    /// Compute an inverse Real FFT over a rlst matrix which stores data corresponding to multiple 3 dimensional arrays of shape `shape`, stored in column major order.
+    /// This function is multithreaded, and uses the FFTW library.
+    ///
+    /// # Arguments
+    /// * `input` - Input slice of complex data, corresponding to an FFT of a 3D array stored in column major order.
+    /// * `output` - Output slice.
+    /// * `shape` - Shape of output data.
+    fn irfft_fftw_par_vec(input: &mut DtypeCplx, output: &mut DtypeReal, shape: &[usize]);
+
+    /// Compute a Real FFT of an input slice corresponding to a 3D array stored in column major format, specified by `shape` using the FFTW library.
+    ///
+    /// # Arguments
+    /// * `input` - Input slice of real data, corresponding to a 3D array stored in column major order.
+    /// * `output` - Output slice.
+    /// * `shape` - Shape of input data.
+    fn rfft3_fftw(input: &mut [Self], output: &mut [Complex<Self>], shape: &[usize]);
+
+    /// Compute an inverse Real FFT of an input slice corresponding to the FFT of a 3D array stored in column major format, specified by `shape` using the FFTW library.
+    /// This function normalises the output.
+    ///
+    /// # Arguments
+    /// * `input` - Input slice of complex data, corresponding to an FFT of a 3D array stored in column major order.
+    /// * `output` - Output slice.
+    /// * `shape` - Shape of output data.
+    fn irfft3_fftw(input: &mut [Complex<Self>], output: &mut [Self], shape: &[usize]);
+}
+
+impl Fft<FftMatrixf32, FftMatrixc32> for f32 {
+    fn rfft3_fftw_par_vec(input: &mut FftMatrixf32, output: &mut FftMatrixc32, shape: &[usize]) {
+        let size: usize = shape.iter().product();
+        let size_d = shape.last().unwrap();
+        let size_real = (size / size_d) * (size_d / 2 + 1);
+        let plan: R2CPlan32 = R2CPlan::aligned(shape, Flag::MEASURE).unwrap();
+
+        let it_inp = input.data_mut().par_chunks_exact_mut(size).into_par_iter();
+        let it_out = output
+            .data_mut()
+            .par_chunks_exact_mut(size_real)
+            .into_par_iter();
+
+        it_inp.zip(it_out).for_each(|(inp, out)| {
+            let _ = plan.r2c(inp, out);
+        });
     }
-}
 
-/// Compute an inverse Real FFT of an input slice corresponding to the FFT of a 3D array stored in column major format, specified by `shape` using the FFTW library.
-/// This function normalises the output.
-///
-/// # Arguments
-/// * `input` - Input slice of complex data, corresponding to an FFT of a 3D array stored in column major order.
-/// * `output` - Output slice.
-/// * `shape` - Shape of output data.
-pub fn irfft3_fftw(input: &mut [c64], output: &mut [f64], shape: &[usize]) {
-    assert!(shape.len() == 3);
-    let size: usize = shape.iter().product();
-    let plan: C2RPlan64 = C2RPlan::aligned(shape, Flag::MEASURE).unwrap();
-    let _ = plan.c2r(input, output);
-    // Normalise
-    output
-        .iter_mut()
-        .for_each(|value| *value *= 1.0 / (size as f64));
-}
+    fn irfft_fftw_par_vec(input: &mut FftMatrixc32, output: &mut FftMatrixf32, shape: &[usize]) {
+        let size: usize = shape.iter().product();
+        let size_d = shape.last().unwrap();
+        let size_real = (size / size_d) * (size_d / 2 + 1);
+        let plan: C2RPlan32 = C2RPlan::aligned(shape, Flag::MEASURE).unwrap();
 
-/// Compute a Real FFT over a rlst matrix which stores data corresponding to multiple 3 dimensional arrays of shape `shape`, stored in column major order.
-/// This function is multithreaded, and uses the FFTW library.
-///
-/// # Arguments
-/// * `input` - Input slice of real data, corresponding to a 3D array stored in column major order.
-/// * `output` - Output slice.
-/// * `shape` - Shape of input data.
-pub fn rfft3_fftw_par_vec_64(input: &mut FftMatrixf64, output: &mut FftMatrixc64, shape: &[usize]) {
-    assert!(shape.len() == 3);
+        let it_inp = input
+            .data_mut()
+            .par_chunks_exact_mut(size_real)
+            .into_par_iter();
+        let it_out = output.data_mut().par_chunks_exact_mut(size).into_par_iter();
 
-    let size: usize = shape.iter().product();
-    let size_d = shape.last().unwrap();
-    let size_real = (size / size_d) * (size_d / 2 + 1);
-
-    let plan: R2CPlan64 = R2CPlan::aligned(shape, Flag::MEASURE).unwrap();
-    let it_inp = input.data_mut().par_chunks_exact_mut(size).into_par_iter();
-    let it_out = output
-        .data_mut()
-        .par_chunks_exact_mut(size_real)
-        .into_par_iter();
-
-    it_inp.zip(it_out).for_each(|(inp, out)| {
-        let _ = plan.r2c(inp, out);
-    });
-}
-
-/// Compute a Real FFT over a rlst matrix which stores data corresponding to multiple 3 dimensional arrays of shape `shape`, stored in column major order.
-/// This function is multithreaded, and uses the FFTW library.
-///
-/// # Arguments
-/// * `input` - Input slice of real data, corresponding to a 3D array stored in column major order.
-/// * `output` - Output slice.
-/// * `shape` - Shape of input data.
-pub fn rfft3_fftw_par_vec_32(input: &mut FftMatrixf32, output: &mut FftMatrixc32, shape: &[usize]) {
-    assert!(shape.len() == 3);
-
-    let size: usize = shape.iter().product();
-    let size_d = shape.last().unwrap();
-    let size_real = (size / size_d) * (size_d / 2 + 1);
-
-    let plan: R2CPlan32 = R2CPlan::aligned(shape, Flag::MEASURE).unwrap();
-    let it_inp = input.data_mut().par_chunks_exact_mut(size).into_par_iter();
-    let it_out = output
-        .data_mut()
-        .par_chunks_exact_mut(size_real)
-        .into_par_iter();
-
-    it_inp.zip(it_out).for_each(|(inp, out)| {
-        let _ = plan.r2c(inp, out);
-    });
-}
-
-pub fn rfft3_fftw_par_vec<'a, R, C>(
-    input: &mut FftMatrix<R>,
-    output: &mut FftMatrix<C>,
-    shape: &[usize],
-) where
-    R: Default + Scalar<Real = R> + Any,
-    C: Default + Scalar<Complex = C> + Any,
-{
-    if TypeId::of::<R>() == TypeId::of::<f32>() && TypeId::of::<C>() == TypeId::of::<c32>() {
-        let input_ptr = input.data().as_ptr() as *const f32;
-        let input_len = input.data().len();
-        let output_ptr = output.data().as_ptr() as *const c32;
-        let output_len = output.data().len();
-
-        let mut input_f32 =
-            unsafe { rlst_pointer_mat!['a, f32, input_ptr , (input_len, 1), (1, input_len)] }
-                .eval();
-        let mut output_c32 =
-            unsafe { rlst_pointer_mat!['a, c32, output_ptr, (output_len, 1), (1, output_len)] }
-                .eval();
-
-        rfft3_fftw_par_vec_32(&mut input_f32, &mut output_c32, shape);
-
-        // rfft3_fftw32(input_f32, output_c32, shape);
-    } else if TypeId::of::<R>() == TypeId::of::<f64>() && TypeId::of::<C>() == TypeId::of::<c64>() {
-        let input_ptr = input.data().as_ptr() as *const f64;
-        let input_len = input.data().len();
-        let output_ptr = output.data().as_ptr() as *const c64;
-        let output_len = output.data().len();
-
-        let mut input_f64 =
-            unsafe { rlst_pointer_mat!['a, f64, input_ptr , (input_len, 1), (1, input_len)] }
-                .eval();
-        let mut output_c64 =
-            unsafe { rlst_pointer_mat!['a, c64, output_ptr, (output_len, 1), (1, output_len)] }
-                .eval();
-
-        rfft3_fftw_par_vec_64(&mut input_f64, &mut output_c64, shape);
+        it_inp.zip(it_out).for_each(|(inp, out)| {
+            let _ = plan.c2r(inp, out);
+            // Normalise output
+            out.iter_mut()
+                .for_each(|value| *value *= 1.0 / (size as f32));
+        })
     }
-}
 
-/// Compute an inverse Real FFT over a rlst matrix which stores data corresponding to multiple 3 dimensional arrays of shape `shape`, stored in column major order.
-/// This function is multithreaded, and uses the FFTW library.
-///
-/// # Arguments
-/// * `input` - Input slice of complex data, corresponding to an FFT of a 3D array stored in column major order.
-/// * `output` - Output slice.
-/// * `shape` - Shape of output data.
-pub fn irfft3_fftw_par_vec_64(
-    input: &mut FftMatrixc64,
-    output: &mut FftMatrixf64,
-    shape: &[usize],
-) {
-    assert!(shape.len() == 3);
-    let size: usize = shape.iter().product();
-    let size_d = shape.last().unwrap();
-    let size_real = (size / size_d) * (size_d / 2 + 1);
-    let plan: C2RPlan64 = C2RPlan::aligned(shape, Flag::MEASURE).unwrap();
+    fn rfft3_fftw(input: &mut [Self], output: &mut [Complex<Self>], shape: &[usize]) {
+        assert!(shape.len() == 3);
+        let plan: R2CPlan32 = R2CPlan::aligned(shape, Flag::MEASURE).unwrap();
+        let _ = plan.r2c(input, output);
+    }
 
-    let it_inp = input
-        .data_mut()
-        .par_chunks_exact_mut(size_real)
-        .into_par_iter();
-    let it_out = output.data_mut().par_chunks_exact_mut(size).into_par_iter();
-
-    it_inp.zip(it_out).for_each(|(inp, out)| {
-        let _ = plan.c2r(inp, out);
-        // Normalise output
-        out.iter_mut()
-            .for_each(|value| *value *= 1.0 / (size as f64));
-    })
-}
-
-/// Compute an inverse Real FFT over a rlst matrix which stores data corresponding to multiple 3 dimensional arrays of shape `shape`, stored in column major order.
-/// This function is multithreaded, and uses the FFTW library.
-///
-/// # Arguments
-/// * `input` - Input slice of complex data, corresponding to an FFT of a 3D array stored in column major order.
-/// * `output` - Output slice.
-/// * `shape` - Shape of output data.
-pub fn irfft3_fftw_par_vec_32(
-    input: &mut FftMatrixc32,
-    output: &mut FftMatrixf32,
-    shape: &[usize],
-) {
-    assert!(shape.len() == 3);
-    let size: usize = shape.iter().product();
-    let size_d = shape.last().unwrap();
-    let size_real = (size / size_d) * (size_d / 2 + 1);
-    let plan: C2RPlan32 = C2RPlan::aligned(shape, Flag::MEASURE).unwrap();
-
-    let it_inp = input
-        .data_mut()
-        .par_chunks_exact_mut(size_real)
-        .into_par_iter();
-    let it_out = output.data_mut().par_chunks_exact_mut(size).into_par_iter();
-
-    it_inp.zip(it_out).for_each(|(inp, out)| {
-        let _ = plan.c2r(inp, out);
-        // Normalise output
-        out.iter_mut()
+    fn irfft3_fftw(input: &mut [Complex<Self>], output: &mut [Self], shape: &[usize]) {
+        assert!(shape.len() == 3);
+        let size: usize = shape.iter().product();
+        let plan: C2RPlan32 = C2RPlan::aligned(shape, Flag::MEASURE).unwrap();
+        let _ = plan.c2r(input, output);
+        // Normalise
+        output
+            .iter_mut()
             .for_each(|value| *value *= 1.0 / (size as f32));
-    })
+    }
 }
 
-pub fn irfft3_fftw_par_vec<'a, R, C>(
-    input: &mut FftMatrix<C>,
-    output: &mut FftMatrix<R>,
-    shape: &[usize],
-) where
-    R: Default + Scalar<Real = R> + Any,
-    C: Default + Scalar<Complex = C> + Any,
-{
-    if TypeId::of::<R>() == TypeId::of::<f32>() && TypeId::of::<C>() == TypeId::of::<c32>() {
-        let input_ptr = input.data().as_ptr() as *const c32;
-        let input_len = input.data().len();
-        let output_ptr = output.data().as_ptr() as *const f32;
-        let output_len = output.data().len();
+impl Fft<FftMatrixf64, FftMatrixc64> for f64 {
+    fn rfft3_fftw_par_vec(input: &mut FftMatrixf64, output: &mut FftMatrixc64, shape: &[usize]) {
+        let size: usize = shape.iter().product();
+        let size_d = shape.last().unwrap();
+        let size_real = (size / size_d) * (size_d / 2 + 1);
+        let plan: R2CPlan64 = R2CPlan::aligned(shape, Flag::MEASURE).unwrap();
 
-        let mut input_c32 =
-            unsafe { rlst_pointer_mat!['a, c32, input_ptr , (input_len, 1), (1, input_len)] }
-                .eval();
-        let mut output_f32 =
-            unsafe { rlst_pointer_mat!['a, f32, output_ptr, (output_len, 1), (1, output_len)] }
-                .eval();
+        let it_inp = input.data_mut().par_chunks_exact_mut(size).into_par_iter();
+        let it_out = output
+            .data_mut()
+            .par_chunks_exact_mut(size_real)
+            .into_par_iter();
 
-        irfft3_fftw_par_vec_32(&mut input_c32, &mut output_f32, shape);
+        it_inp.zip(it_out).for_each(|(inp, out)| {
+            let _ = plan.r2c(inp, out);
+        });
+    }
+    fn irfft_fftw_par_vec(input: &mut FftMatrixc64, output: &mut FftMatrixf64, shape: &[usize]) {
+        let size: usize = shape.iter().product();
+        let size_d = shape.last().unwrap();
+        let size_real = (size / size_d) * (size_d / 2 + 1);
+        let plan: C2RPlan64 = C2RPlan::aligned(shape, Flag::MEASURE).unwrap();
 
-        // rfft3_fftw32(input_f32, output_c32, shape);
-    } else if TypeId::of::<R>() == TypeId::of::<f64>() && TypeId::of::<C>() == TypeId::of::<c64>() {
-        let input_ptr = input.data().as_ptr() as *const c64;
-        let input_len = input.data().len();
-        let output_ptr = output.data().as_ptr() as *const f64;
-        let output_len = output.data().len();
+        let it_inp = input
+            .data_mut()
+            .par_chunks_exact_mut(size_real)
+            .into_par_iter();
+        let it_out = output.data_mut().par_chunks_exact_mut(size).into_par_iter();
 
-        let mut input_c64 =
-            unsafe { rlst_pointer_mat!['a, c64, input_ptr , (input_len, 1), (1, input_len)] }
-                .eval();
-        let mut output_f64 =
-            unsafe { rlst_pointer_mat!['a, f64, output_ptr, (output_len, 1), (1, output_len)] }
-                .eval();
+        it_inp.zip(it_out).for_each(|(inp, out)| {
+            let _ = plan.c2r(inp, out);
+            // Normalise output
+            out.iter_mut()
+                .for_each(|value| *value *= 1.0 / (size as f64));
+        })
+    }
 
-        irfft3_fftw_par_vec_64(&mut input_c64, &mut output_f64, shape);
+    fn rfft3_fftw(input: &mut [Self], output: &mut [Complex<Self>], shape: &[usize]) {
+        assert!(shape.len() == 3);
+        let plan: R2CPlan64 = R2CPlan::aligned(shape, Flag::MEASURE).unwrap();
+        let _ = plan.r2c(input, output);
+    }
+
+    fn irfft3_fftw(input: &mut [Complex<Self>], output: &mut [Self], shape: &[usize]) {
+        assert!(shape.len() == 3);
+        let size: usize = shape.iter().product();
+        let plan: C2RPlan64 = C2RPlan::aligned(shape, Flag::MEASURE).unwrap();
+        let _ = plan.c2r(input, output);
+        // Normalise
+        output
+            .iter_mut()
+            .for_each(|value| *value *= 1.0 / (size as f64));
     }
 }

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -49,7 +49,7 @@ where
             Dynamic,
         >,
     DenseMatrixLinAlgBuilder<T>: Svd,
-    T: Scalar<Real = <DenseMatrixLinAlgBuilder<T> as Svd>::T>,
+    T: Scalar<Real = T>,
     U: Kernel<T = T> + Default,
 {
     type TransferVector = Vec<TransferVector>;
@@ -177,7 +177,7 @@ where
             Dynamic,
         >,
     DenseMatrixLinAlgBuilder<T>: Svd,
-    T: Scalar<Real = <DenseMatrixLinAlgBuilder<T> as Svd>::T>,
+    T: Scalar<Real = T>,
     U: Kernel<T = T> + Default,
 {
     /// Constructor for SVD field translation struct for the kernel independent FMM (KiFMM).

--- a/field/src/types.rs
+++ b/field/src/types.rs
@@ -1,5 +1,5 @@
 //! Types for storing field translation data.
-use std::collections::HashMap;
+use std::{collections::HashMap, io::Read};
 
 use num::Float;
 use rlst::{
@@ -51,7 +51,7 @@ where
 /// A type to store the M2L field translation meta-data  and datafor an SVD based sparsification in the kernel independent FMM.
 pub struct SvdFieldTranslationKiFmm<T, U>
 where
-    T: Scalar + Float + Default,
+    T: Scalar<Real = T> + Float + Default,
     U: Kernel<T = T> + Default,
 {
     /// Amount to dilate inner check surface by when computing operator.

--- a/field/src/types.rs
+++ b/field/src/types.rs
@@ -1,7 +1,8 @@
 //! Types for storing field translation data.
-use std::{collections::HashMap, io::Read};
+use std::collections::HashMap;
 
-use num::Float;
+use cauchy::{c32, c64};
+use num::{Complex, Float};
 use rlst::{
     common::traits::{Eval, NewLikeSelf},
     dense::{
@@ -23,11 +24,10 @@ pub type SvdM2lEntry<T> = Matrix<T, BaseMatrix<T, VectorContainer<T>, Dynamic>, 
 pub type FftKernelData<C> = Vec<Vec<C>>;
 
 /// A type to store the M2L field translation meta-data and data for an FFT based sparsification in the kernel independent FMM.
-pub struct FftFieldTranslationKiFmm<T, U, V>
+pub struct FftFieldTranslationKiFmm<T, U>
 where
     T: Default + Scalar<Real = T> + Float,
-    U: Default + Scalar<Complex = U>,
-    V: Kernel<T = T> + Default,
+    U: Kernel<T = T> + Default,
 {
     /// Amount to dilate inner check surface by
     pub alpha: T,
@@ -39,13 +39,13 @@ where
     pub conv_to_surf_map: HashMap<usize, usize>,
 
     /// Precomputed data required for FFT compressed M2L interaction.
-    pub operator_data: FftM2lOperatorData<U>,
+    pub operator_data: FftM2lOperatorData<Complex<T>>,
 
     /// Unique transfer vectors to lookup m2l unique kernel interactions
     pub transfer_vectors: Vec<TransferVector>,
 
     /// The associated kernel with this translation operator.
-    pub kernel: V,
+    pub kernel: U,
 }
 
 /// A type to store the M2L field translation meta-data  and datafor an SVD based sparsification in the kernel independent FMM.
@@ -126,3 +126,18 @@ where
         }
     }
 }
+
+/// Type alias for real coefficients for into FFTW wrappers
+pub type FftMatrixf64 = Matrix<f64, BaseMatrix<f64, VectorContainer<f64>, Dynamic>, Dynamic>;
+
+/// Type alias for real coefficients for into FFTW wrappers
+pub type FftMatrixf32 = Matrix<f32, BaseMatrix<f32, VectorContainer<f32>, Dynamic>, Dynamic>;
+
+/// Type alias for complex coefficients for FFTW wrappers
+pub type FftMatrixc64 = Matrix<c64, BaseMatrix<c64, VectorContainer<c64>, Dynamic>, Dynamic>;
+
+/// Type alias for complex coefficients for FFTW wrappers
+pub type FftMatrixc32 = Matrix<c32, BaseMatrix<c32, VectorContainer<c32>, Dynamic>, Dynamic>;
+
+/// Type alias for real coefficients for into FFTW wrappers
+pub type FftMatrix<T> = Matrix<T, BaseMatrix<T, VectorContainer<T>, Dynamic>, Dynamic>;

--- a/field/src/types.rs
+++ b/field/src/types.rs
@@ -23,14 +23,14 @@ pub type SvdM2lEntry<T> = Matrix<T, BaseMatrix<T, VectorContainer<T>, Dynamic>, 
 pub type FftKernelData<C> = Vec<Vec<C>>;
 
 /// A type to store the M2L field translation meta-data and data for an FFT based sparsification in the kernel independent FMM.
-pub struct FftFieldTranslationKiFmm<K, R, C>
+pub struct FftFieldTranslationKiFmm<T, U, V>
 where
-    R: Default + Scalar<Real = R> + Float,
-    C: Default + Scalar<Complex = C>,
-    K: Kernel + Default,
+    T: Default + Scalar<Real = T> + Float,
+    U: Default + Scalar<Complex = U>,
+    V: Kernel<T = T> + Default,
 {
     /// Amount to dilate inner check surface by
-    pub alpha: R,
+    pub alpha: T,
 
     /// Map between indices of surface convolution grid points.
     pub surf_to_conv_map: HashMap<usize, usize>,
@@ -39,20 +39,20 @@ where
     pub conv_to_surf_map: HashMap<usize, usize>,
 
     /// Precomputed data required for FFT compressed M2L interaction.
-    pub operator_data: FftM2lOperatorData<C>,
+    pub operator_data: FftM2lOperatorData<U>,
 
     /// Unique transfer vectors to lookup m2l unique kernel interactions
     pub transfer_vectors: Vec<TransferVector>,
 
     /// The associated kernel with this translation operator.
-    pub kernel: K,
+    pub kernel: V,
 }
 
 /// A type to store the M2L field translation meta-data  and datafor an SVD based sparsification in the kernel independent FMM.
-pub struct SvdFieldTranslationKiFmm<K, T>
+pub struct SvdFieldTranslationKiFmm<T, U>
 where
     T: Scalar + Float + Default,
-    K: Kernel<T = T> + Default,
+    U: Kernel<T = T> + Default,
 {
     /// Amount to dilate inner check surface by when computing operator.
     pub alpha: T,
@@ -67,7 +67,7 @@ where
     pub transfer_vectors: Vec<TransferVector>,
 
     /// The associated kernel with this translation operator.
-    pub kernel: K,
+    pub kernel: U,
 }
 
 /// A type to store a transfer vector between a `source` and `target` Morton key.

--- a/field/src/types.rs
+++ b/field/src/types.rs
@@ -1,8 +1,6 @@
 //! Types for storing field translation data.
 use std::collections::HashMap;
 
-use cauchy::{c64, Scalar};
-
 use num::Float;
 use rlst::{
     common::traits::{Eval, NewLikeSelf},
@@ -13,6 +11,7 @@ use rlst::{
 };
 
 use bempp_traits::kernel::Kernel;
+use bempp_traits::types::Scalar;
 use bempp_tree::types::morton::MortonKey;
 
 /// Simple type alias for a 2D `Matrix<f64>`

--- a/fmm/src/charge.rs
+++ b/fmm/src/charge.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
-use crate::types::{Charge, ChargeDict, GlobalIdx};
+use crate::types::{Charge64, ChargeDict, GlobalIdx};
 
-pub fn build_charge_dict(global_idxs: &[GlobalIdx], charges: &[Charge]) -> ChargeDict {
+pub fn build_charge_dict(global_idxs: &[GlobalIdx], charges: &[Charge64]) -> ChargeDict {
     let mut res: ChargeDict = HashMap::new();
     for (&global_idx, &charge) in global_idxs.iter().zip(charges.iter()) {
         res.insert(global_idx, charge);

--- a/fmm/src/charge.rs
+++ b/fmm/src/charge.rs
@@ -1,9 +1,15 @@
 use std::collections::HashMap;
 
-use crate::types::{Charge64, ChargeDict, GlobalIdx};
+use cauchy::Scalar;
+use num::Float;
 
-pub fn build_charge_dict(global_idxs: &[GlobalIdx], charges: &[Charge64]) -> ChargeDict {
-    let mut res: ChargeDict = HashMap::new();
+use crate::types::{Charge, ChargeDict, GlobalIdx};
+
+pub fn build_charge_dict<T>(global_idxs: &[GlobalIdx], charges: &[Charge<T>]) -> ChargeDict<T>
+where
+    T: Float + Scalar + Default,
+{
+    let mut res: ChargeDict<T> = HashMap::new();
     for (&global_idx, &charge) in global_idxs.iter().zip(charges.iter()) {
         res.insert(global_idx, charge);
     }

--- a/fmm/src/field_translation.rs
+++ b/fmm/src/field_translation.rs
@@ -1,18 +1,19 @@
 //! Implementation of field translations for each FMM.
 use std::{
     collections::HashMap,
-    ops::{Deref, DerefMut},
+    ops::{Deref, DerefMut, Mul},
     sync::{Arc, Mutex, RwLock},
 };
 
 use bempp_tools::Array3D;
 use fftw::types::*;
 use itertools::Itertools;
+use num::Float;
 use rayon::prelude::*;
 
 use bempp_field::{
     array::pad3,
-    fft::{irfft3_fftw_par_vec, rfft3_fftw_par_vec},
+    fft::{irfft3_fftw_par_vec, rfft3_fftw_par_vec, rfft3_fftw_par_vec_64},
     types::{FftFieldTranslationKiFmm, SvdFieldTranslationKiFmm},
 };
 
@@ -26,17 +27,34 @@ use bempp_traits::{
 };
 use bempp_tree::types::{morton::MortonKey, single_node::SingleNodeTree};
 
+use num::complex::ComplexFloat;
+
 use rlst::{
+    algorithms::{linalg::DenseMatrixLinAlgBuilder, traits::svd::Svd},
+    blis::interface::gemm::Gemm,
     common::traits::*,
-    dense::{rlst_col_vec, rlst_dynamic_mat, rlst_pointer_mat, traits::*, Dot, Shape},
+    dense::{
+        rlst_col_vec, rlst_dynamic_mat, rlst_pointer_mat, traits::*, Dot, MultiplyAdd, Shape,
+        VectorContainer,
+    },
 };
 
 use crate::types::{FmmData, KiFmm};
 
-impl<T, U> SourceTranslation for FmmData<KiFmm<SingleNodeTree, T, U>>
+impl<T, U, V> SourceTranslation for FmmData<KiFmm<SingleNodeTree<V>, T, U, V>, V>
 where
-    T: Kernel<T = f64> + KernelScale<T = f64> + std::marker::Send + std::marker::Sync,
+    T: Kernel<T = V> + KernelScale<T = V> + std::marker::Send + std::marker::Sync,
     U: FieldTranslationData<T> + std::marker::Sync + std::marker::Send,
+    V: Scalar<Real = V> + Float + Default + std::marker::Sync + std::marker::Send,
+    V: MultiplyAdd<
+        V,
+        VectorContainer<V>,
+        VectorContainer<V>,
+        VectorContainer<V>,
+        Dynamic,
+        Dynamic,
+        Dynamic,
+    >,
 {
     /// Point to multipole evaluations, multithreaded over each leaf box.
     fn p2m<'a>(&self) {
@@ -58,7 +76,7 @@ where
                     let nsources = leaf_coordinates.len() / self.fmm.kernel.space_dimension();
 
                     let leaf_coordinates = unsafe {
-                        rlst_pointer_mat!['a, f64, leaf_coordinates.as_ptr(), (nsources, fmm_arc.kernel.space_dimension()), (fmm_arc.kernel.space_dimension(), 1)]
+                        rlst_pointer_mat!['a, V, leaf_coordinates.as_ptr(), (nsources, fmm_arc.kernel.space_dimension()), (fmm_arc.kernel.space_dimension(), 1)]
                     }.eval();
 
                     let upward_check_surface = leaf.compute_surface(
@@ -71,7 +89,7 @@ where
                     let leaf_charges = leaf_charges_arc.deref();
 
                     // Calculate check potential
-                    let mut check_potential = rlst_col_vec![f64, ntargets];
+                    let mut check_potential = rlst_col_vec![V, ntargets];
 
                     fmm_arc.kernel.evaluate_st(
                         EvalType::Value,
@@ -81,10 +99,14 @@ where
                         check_potential.data_mut(),
                     );
 
-                    let leaf_multipole_owned = (
-                        fmm_arc.kernel.scale(leaf.level())
-                        * fmm_arc.uc2e_inv_1.dot(&fmm_arc.uc2e_inv_2.dot(&check_potential))
-                    ).eval();
+                    // let leaf_multipole_owned = (
+                    //     fmm_arc.kernel.scale(leaf.level())
+                    //     * fmm_arc.uc2e_inv_1.dot(&fmm_arc.uc2e_inv_2.dot(&check_potential))
+                    // ).eval();
+
+                    let mut tmp = fmm_arc.uc2e_inv_1.dot(&fmm_arc.uc2e_inv_2.dot(&check_potential)).eval();
+                    tmp.data_mut().iter_mut().for_each(|d| *d  *= fmm_arc.kernel.scale(leaf.level()));
+                    let leaf_multipole_owned = tmp;
 
                     let mut leaf_multipole_lock = leaf_multipole_arc.lock().unwrap();
 
@@ -119,10 +141,20 @@ where
     }
 }
 
-impl<T, U> TargetTranslation for FmmData<KiFmm<SingleNodeTree, T, U>>
+impl<T, U, V> TargetTranslation for FmmData<KiFmm<SingleNodeTree<V>, T, U, V>, V>
 where
-    T: Kernel<T = f64> + KernelScale<T = f64> + std::marker::Sync + std::marker::Send,
+    T: Kernel<T = V> + KernelScale<T = V> + std::marker::Send + std::marker::Sync,
     U: FieldTranslationData<T> + std::marker::Sync + std::marker::Send,
+    V: Scalar<Real = V> + Float + Default + std::marker::Sync + std::marker::Send,
+    V: MultiplyAdd<
+        V,
+        VectorContainer<V>,
+        VectorContainer<V>,
+        VectorContainer<V>,
+        Dynamic,
+        Dynamic,
+        Dynamic,
+    >,
 {
     fn l2l(&self, level: u64) {
         if let Some(targets) = self.fmm.tree().get_keys(level) {
@@ -174,10 +206,11 @@ where
                             let ntargets = target_coordinates.len() / self.fmm.kernel.space_dimension();
 
                             let target_coordinates = unsafe {
-                                rlst_pointer_mat!['a, f64, target_coordinates.as_ptr(), (ntargets, fmm_arc.kernel.space_dimension()), (fmm_arc.kernel.space_dimension(), 1)]
+                                rlst_pointer_mat!['a, V, target_coordinates.as_ptr(), (ntargets, fmm_arc.kernel.space_dimension()), (fmm_arc.kernel.space_dimension(), 1)]
                             }.eval();
 
-                            let mut target_potential = rlst_col_vec![f64, ntargets];
+
+                            let mut target_potential = rlst_col_vec![V, ntargets];
 
                             fmm_arc.kernel.evaluate_st(
                                 EvalType::Value,
@@ -215,7 +248,7 @@ where
                     let ntargets = target_coordinates.len() / self.fmm.kernel.space_dimension();
 
                     let target_coordinates = unsafe {
-                        rlst_pointer_mat!['a, f64, target_coordinates.as_ptr(), (ntargets, fmm_arc.kernel.space_dimension()), (fmm_arc.kernel.space_dimension(), 1)]
+                        rlst_pointer_mat!['a, V, target_coordinates.as_ptr(), (ntargets, fmm_arc.kernel.space_dimension()), (fmm_arc.kernel.space_dimension(), 1)]
                     }.eval();
 
                     let downward_equivalent_surface = leaf.compute_surface(
@@ -226,7 +259,7 @@ where
 
                     let source_local_lock = source_local_arc.lock().unwrap();
 
-                    let mut target_potential = rlst_col_vec![f64, ntargets];
+                    let mut target_potential = rlst_col_vec![V, ntargets];
 
                     fmm_arc.kernel.evaluate_st(
                         EvalType::Value,
@@ -262,7 +295,7 @@ where
                             let nsources = source_coordinates.len() / self.fmm.kernel.space_dimension();
 
                             let source_coordinates = unsafe {
-                                rlst_pointer_mat!['a, f64, source_coordinates.as_ptr(), (nsources, fmm_arc.kernel.space_dimension()), (fmm_arc.kernel.space_dimension(), 1)]
+                                rlst_pointer_mat!['a, V, source_coordinates.as_ptr(), (nsources, fmm_arc.kernel.space_dimension()), (fmm_arc.kernel.space_dimension(), 1)]
                             }.eval();
 
                             let source_charges = self.charges.get(source).unwrap();
@@ -274,7 +307,7 @@ where
                             );
 
                             let ntargets = downward_check_surface.len() / fmm_arc.kernel.space_dimension();
-                            let mut downward_check_potential = rlst_col_vec![f64, ntargets];
+                            let mut downward_check_potential = rlst_col_vec![V, ntargets];
 
                             fmm_arc.kernel.evaluate_st(
                                 EvalType::Value,
@@ -287,7 +320,11 @@ where
 
                             let mut target_local_lock = target_local_arc.lock().unwrap();
 
-                            let target_local_owned = (fmm_arc.kernel.scale(leaf.level()) * fmm_arc.dc2e_inv_1.dot(&fmm_arc.dc2e_inv_2.dot(&downward_check_potential))).eval();
+                            // let target_local_owned = (fmm_arc.kernel.scale(leaf.level()) * fmm_arc.dc2e_inv_1.dot(&fmm_arc.dc2e_inv_2.dot(&downward_check_potential))).eval();
+
+                            let mut tmp = fmm_arc.dc2e_inv_1.dot(&fmm_arc.dc2e_inv_2.dot(&downward_check_potential)).eval();
+                            tmp.data_mut().iter_mut().for_each(|d| *d *=  fmm_arc.kernel.scale(leaf.level()));
+                            let target_local_owned =  tmp;
 
                             *target_local_lock.deref_mut() = (target_local_lock.deref() + target_local_owned).eval();
                         }
@@ -313,7 +350,7 @@ where
                     let ntargets= target_coordinates.len() / self.fmm.kernel.space_dimension();
 
                     let target_coordinates = unsafe {
-                        rlst_pointer_mat!['a, f64, target_coordinates.as_ptr(), (ntargets, fmm_arc.kernel.space_dimension()), (fmm_arc.kernel.space_dimension(), 1)]
+                        rlst_pointer_mat!['a, V, target_coordinates.as_ptr(), (ntargets, fmm_arc.kernel.space_dimension()), (fmm_arc.kernel.space_dimension(), 1)]
                     }.eval();
 
                     if let Some(u_list) = fmm_arc.get_u_list(&target) {
@@ -328,13 +365,13 @@ where
                                 let nsources = source_coordinates.len() / self.fmm.kernel.space_dimension();
 
                                 let source_coordinates = unsafe {
-                                    rlst_pointer_mat!['a, f64, source_coordinates.as_ptr(), (nsources, fmm_arc.kernel.space_dimension()), (fmm_arc.kernel.space_dimension(), 1)]
+                                    rlst_pointer_mat!['a, V, source_coordinates.as_ptr(), (nsources, fmm_arc.kernel.space_dimension()), (fmm_arc.kernel.space_dimension(), 1)]
                                 }.eval();
 
                                 let source_charges_arc =
                                     Arc::clone(self.charges.get(source).unwrap());
 
-                                let mut target_potential = rlst_col_vec![f64, ntargets];
+                                let mut target_potential = rlst_col_vec![V, ntargets];
 
                                 fmm_arc.kernel.evaluate_st(
                                     EvalType::Value,
@@ -358,9 +395,24 @@ where
 }
 
 /// Implement the multipole to local translation operator for an SVD accelerated KiFMM on a single node.
-impl<T> FieldTranslation for FmmData<KiFmm<SingleNodeTree, T, SvdFieldTranslationKiFmm<T>>>
+impl<T, U> FieldTranslation<U>
+    for FmmData<KiFmm<SingleNodeTree<U>, T, SvdFieldTranslationKiFmm<U, T>, U>, U>
 where
-    T: Kernel<T = f64> + KernelScale<T = f64> + std::marker::Sync + std::marker::Send + Default,
+    T: Kernel<T = U> + KernelScale<T = U> + std::marker::Send + std::marker::Sync + Default,
+    DenseMatrixLinAlgBuilder<U>: Svd,
+    U: Scalar<Real = U>,
+    U: Float
+        + Default
+        + MultiplyAdd<
+            U,
+            VectorContainer<U>,
+            VectorContainer<U>,
+            VectorContainer<U>,
+            Dynamic,
+            Dynamic,
+            Dynamic,
+        >,
+    U: std::marker::Send + std::marker::Sync + Default,
 {
     fn m2l<'a>(&self, level: u64) {
         let Some(targets) = self.fmm.tree().get_keys(level) else {
@@ -420,7 +472,7 @@ where
                 let c_sub = self.fmm.m2l.operator_data.c.block(top_left, dim);
 
                 let m2l_rw = m2l_arc.read().unwrap();
-                let mut multipoles = rlst_dynamic_mat![f64, (self.fmm.m2l.k, m2l_rw.len())];
+                let mut multipoles = rlst_dynamic_mat![U, (self.fmm.m2l.k, m2l_rw.len())];
 
                 for (i, (source, _)) in m2l_rw.iter().enumerate() {
                     let source_multipole_arc = Arc::clone(self.multipoles.get(source).unwrap());
@@ -454,16 +506,14 @@ where
                     .dot(&compressed_check_potential_owned)
                     .eval();
 
-                // println!("check potential svd {:?}", check_potential_owned.data());
-
-                // Compute local
-                let locals_owned = (self
+                let mut tmp = self
                     .fmm
                     .dc2e_inv_1
-                    .dot(&self.fmm.dc2e_inv_2.dot(&check_potential_owned))
-                    * self.fmm.kernel.scale(level)
-                    * self.m2l_scale(level))
-                .eval();
+                    .dot(&self.fmm.dc2e_inv_2.dot(&check_potential_owned));
+                tmp.data_mut()
+                    .iter_mut()
+                    .for_each(|d| *d *= self.fmm.kernel.scale(level) * self.m2l_scale(level));
+                let locals_owned = tmp;
 
                 // Assign locals
                 for (i, (_, target)) in m2l_rw.iter().enumerate() {
@@ -480,15 +530,16 @@ where
             });
     }
 
-    fn m2l_scale(&self, level: u64) -> f64 {
+    fn m2l_scale(&self, level: u64) -> U {
         if level < 2 {
-            panic!("M2L only performed on level 2 and below")
+            panic!("M2L only perfomed on level 2 and below")
         }
 
         if level == 2 {
-            1. / 2.
+            U::from(1. / 2.).unwrap()
         } else {
-            2_f64.powf((level - 3) as f64)
+            let two = U::from(2.0).unwrap();
+            Scalar::powf(two, U::from(level - 3).unwrap())
         }
     }
 }
@@ -508,9 +559,33 @@ struct SendPtr<T> {
 unsafe impl<T> Sync for SendPtr<T> {}
 
 /// Implement the multipole to local translation operator for an FFT accelerated KiFMM on a single node.
-impl<T> FieldTranslation for FmmData<KiFmm<SingleNodeTree, T, FftFieldTranslationKiFmm<T>>>
+impl<T, U, V> FieldTranslation<U>
+    for FmmData<KiFmm<SingleNodeTree<U>, T, FftFieldTranslationKiFmm<U, V, T>, U>, U>
 where
-    T: Kernel<T = f64> + KernelScale<T = f64> + std::marker::Sync + std::marker::Send + Default,
+    T: Kernel<T = U> + KernelScale<T = U> + std::marker::Send + std::marker::Sync + Default,
+    U: Scalar<Real = U>
+        + Float
+        + Default
+        + std::marker::Send
+        + std::marker::Sync
+        + std::ops::Mul<V, Output = V>,
+    V: Scalar<Complex = V>
+        + ComplexFloat
+        + Default
+        + std::ops::Mul<U, Output = V>
+        + std::marker::Send
+        + std::marker::Sync
+        + std::ops::AddAssign<V>,
+    U: MultiplyAdd<
+        U,
+        VectorContainer<U>,
+        VectorContainer<U>,
+        VectorContainer<U>,
+        Dynamic,
+        Dynamic,
+        Dynamic,
+    >,
+    // <U as Mul<V>>::Output: Mul<V>
 {
     fn m2l<'a>(&self, level: u64) {
         let Some(targets) = self.fmm.tree().get_keys(level) else {
@@ -531,7 +606,7 @@ where
         let size_real = p * q * (r / 2 + 1);
         let pad_size = (p - m, q - n, r - o);
         let pad_index = (p - m, q - n, r - o);
-        let mut padded_signals = rlst_col_vec![f64, size * ntargets];
+        let mut padded_signals = rlst_col_vec![U, size * ntargets];
 
         let chunks = padded_signals.data_mut().par_chunks_exact_mut(size);
 
@@ -550,14 +625,14 @@ where
             chunk.copy_from_slice(padded_signal.get_data());
         });
 
-        let mut padded_signals_hat = rlst_col_vec![c64, size_real * ntargets];
+        let mut padded_signals_hat = rlst_col_vec![V, size_real * ntargets];
         rfft3_fftw_par_vec(&mut padded_signals, &mut padded_signals_hat, &[p, q, r]);
 
         let kernel_data_halo = &self.fmm.m2l.operator_data.kernel_data_rearranged;
         let ntargets = targets.len();
         let nparents = ntargets / 8;
-        let mut global_check_potentials_hat = rlst_col_vec![c64, size_real * ntargets];
-        let mut global_check_potentials = rlst_col_vec![f64, size * ntargets];
+        let mut global_check_potentials_hat = rlst_col_vec![V, size_real * ntargets];
+        let mut global_check_potentials = rlst_col_vec![U, size * ntargets];
 
         // Get check potentials in frequency order
         let mut global_check_potentials_hat_freq = vec![Vec::new(); size_real];
@@ -579,7 +654,7 @@ where
 
         // Get signals into frequency order
         let mut padded_signals_hat_freq = vec![Vec::new(); size_real];
-        let zero = rlst_col_vec![c64, 8];
+        let zero = rlst_col_vec![V, 8];
         unsafe {
             let ptr = padded_signals_hat.get_pointer();
 
@@ -630,7 +705,6 @@ where
                             }
                         } else {
                             for i in 0..8 {
-                                // tmp.push(-1 as i64)
                                 tmp.push(ntargets + i)
                             }
                         }
@@ -647,7 +721,7 @@ where
             all_displacements.push(displacements);
         });
 
-        let scale = self.m2l_scale(level);
+        let scale = V::from(self.m2l_scale(level)).unwrap();
 
         (0..size_real).into_par_iter().for_each(|freq| {
             // Extract frequency component of signal (ntargets long)
@@ -672,7 +746,6 @@ where
 
                     // Lookup signal to be translated if a translation is to be performed
                     let signal = &padded_signal_freq[(displacements[0])..=(displacements[7])];
-
                     for j in 0..8 {
                         let kernel_data_ij = &kernel_data_i[j * 8..(j + 1) * 8];
                         let sig = signal[j].raw;
@@ -680,7 +753,7 @@ where
                             save_locations_raw
                                 .iter()
                                 .zip(kernel_data_ij.iter())
-                                .for_each(|(&sav, ker)| *sav += scale * *sig * ker)
+                                .for_each(|(&sav, ker)|  {*sav += scale * *sig * *ker;})
                         }
                     } // inner loop
                 }
@@ -694,7 +767,7 @@ where
         );
 
         // Compute local expansion coefficients and save to data tree
-        let (_, multi_indices) = MortonKey::surface_grid(self.fmm.order);
+        let (_, multi_indices) = MortonKey::surface_grid::<U>(self.fmm.order);
 
         let check_potentials = global_check_potentials
             .data()
@@ -721,15 +794,25 @@ where
 
         let ncoeffs = self.fmm.m2l.ncoeffs(self.fmm.order);
         let check_potentials = unsafe {
-            rlst_pointer_mat!['a, f64, check_potentials.as_ptr(), (ncoeffs, ntargets), (1, ncoeffs)]
+            rlst_pointer_mat!['a, U, check_potentials.as_ptr(), (ncoeffs, ntargets), (1, ncoeffs)]
         };
 
-        let locals = (self
+        // let locals = (self
+        //     .fmm
+        //     .dc2e_inv_1
+        //     .dot(&self.fmm.dc2e_inv_2.dot(&check_potentials))
+        //     * self.fmm.kernel.scale(level))
+        // .eval();
+
+        let mut tmp = self
             .fmm
             .dc2e_inv_1
             .dot(&self.fmm.dc2e_inv_2.dot(&check_potentials))
-            * self.fmm.kernel.scale(level))
-        .eval();
+            .eval();
+        tmp.data_mut()
+            .iter_mut()
+            .for_each(|d| *d *= self.fmm.kernel.scale(level));
+        let locals = tmp;
 
         for (i, target) in targets.iter().enumerate() {
             let target_local_arc = Arc::clone(self.locals.get(target).unwrap());
@@ -744,14 +827,16 @@ where
         }
     }
 
-    fn m2l_scale(&self, level: u64) -> f64 {
+    fn m2l_scale(&self, level: u64) -> U {
         if level < 2 {
-            panic!("M2L only performed on level 2 and below")
+            panic!("M2L only perfomed on level 2 and below")
         }
+
         if level == 2 {
-            1. / 2.
+            U::from(1. / 2.).unwrap()
         } else {
-            2_f64.powf((level - 3) as f64)
+            let two = U::from(2.0).unwrap();
+            Scalar::powf(two, U::from(level - 3).unwrap())
         }
     }
 }

--- a/fmm/src/fmm.rs
+++ b/fmm/src/fmm.rs
@@ -584,11 +584,10 @@ mod test {
             &global_idxs[..],
         );
 
-        let m2l_data_fft: FftFieldTranslationKiFmm<f64, c64, Laplace3dKernel<f64>> =
+        let m2l_data_fft =
             FftFieldTranslationKiFmm::new(kernel.clone(), order, *tree.get_domain(), alpha_inner);
 
-        let fmm: KiFmm<SingleNodeTree<f64>, _, _, f64> =
-            KiFmm::new(order, alpha_inner, alpha_outer, kernel, tree, m2l_data_fft);
+        let fmm = KiFmm::new(order, alpha_inner, alpha_outer, kernel, tree, m2l_data_fft);
 
         // Form charge dict, matching charges with their associated global indices
         let charge_dict = build_charge_dict(&global_idxs[..], &charges[..]);
@@ -636,7 +635,12 @@ mod test {
             .map(|(a, b)| (a - b).abs())
             .sum();
 
-        println!("HERE {:?} \n{:?} \n{:?}", leaf.morton(), potentials.data(), direct);
+        println!(
+            "HERE {:?} \n{:?} \n{:?}",
+            leaf.morton(),
+            potentials.data(),
+            direct
+        );
         let rel_error: f64 = abs_error / (direct.iter().sum::<f64>());
         println!("rel error {:?}", rel_error);
         assert!(rel_error <= 1e-6);

--- a/fmm/src/interaction_lists.rs
+++ b/fmm/src/interaction_lists.rs
@@ -1,18 +1,21 @@
 //! Implementation of interaction lists for FMMs (single and multi node)
+use cauchy::Scalar;
 use itertools::Itertools;
 
 use bempp_traits::{
     field::FieldTranslationData, fmm::InteractionLists, kernel::Kernel, tree::Tree,
 };
 use bempp_tree::types::morton::{MortonKey, MortonKeys};
+use num::Float;
 
 use crate::types::KiFmm;
 
-impl<T, U, V> InteractionLists for KiFmm<T, U, V>
+impl<T, U, V, W> InteractionLists for KiFmm<T, U, V, W>
 where
     T: Tree<NodeIndex = MortonKey, NodeIndices = MortonKeys>,
-    U: Kernel,
+    U: Kernel<T = W>,
     V: FieldTranslationData<U>,
+    W: Scalar + Float + Default,
 {
     type Tree = T;
 

--- a/fmm/src/types.rs
+++ b/fmm/src/types.rs
@@ -5,63 +5,75 @@ use std::{
 
 use bempp_traits::{field::FieldTranslationData, fmm::Fmm, kernel::Kernel, tree::Tree};
 use bempp_tree::types::{morton::MortonKey, point::Point};
+use cauchy::Scalar;
+use num::Float;
 use rlst::dense::traits::*;
 use rlst::dense::{base_matrix::BaseMatrix, data_container::VectorContainer, matrix::Matrix};
 use rlst::{self};
 
 /// Type alias for charge data
-pub type Charge = f64;
+pub type Charge<T> = T;
 
 /// Type alias for global index for identifying charge data with a point
 pub type GlobalIdx = usize;
 
 /// Type alias for mapping charge data to global indices.
-pub type ChargeDict = HashMap<GlobalIdx, Charge>;
+pub type ChargeDict<T> = HashMap<GlobalIdx, Charge<T>>;
 
 /// Type alias for multipole/local expansion containers.
-pub type Expansions = Matrix<f64, BaseMatrix<f64, VectorContainer<f64>, Dynamic>, Dynamic>;
+pub type Expansions<T> = Matrix<T, BaseMatrix<T, VectorContainer<T>, Dynamic>, Dynamic>;
 
 /// Type alias for potential containers.
-pub type Potentials = Matrix<f64, BaseMatrix<f64, VectorContainer<f64>, Dynamic>, Dynamic>;
+pub type Potentials<T> = Matrix<T, BaseMatrix<T, VectorContainer<T>, Dynamic>, Dynamic>;
 
 /// Type alias for approximation of FMM operator matrices.
-pub type C2EType = Matrix<f64, BaseMatrix<f64, VectorContainer<f64>, Dynamic>, Dynamic>;
+pub type C2EType<T> = Matrix<T, BaseMatrix<T, VectorContainer<T>, Dynamic>, Dynamic>;
 
 /// Type to store data associated with an FMM in.
-pub struct FmmData<T: Fmm> {
+pub struct FmmData<T, U>
+where
+    T: Fmm,
+    U: Scalar + Float + Default,
+{
     /// The associated FMM object, which implements an FMM interface
     pub fmm: Arc<T>,
 
     /// The multipole expansion data at each box.
-    pub multipoles: HashMap<MortonKey, Arc<Mutex<Expansions>>>,
+    pub multipoles: HashMap<MortonKey, Arc<Mutex<Expansions<U>>>>,
 
     /// The local expansion data at each box.
-    pub locals: HashMap<MortonKey, Arc<Mutex<Expansions>>>,
+    pub locals: HashMap<MortonKey, Arc<Mutex<Expansions<U>>>>,
 
     /// The evaluated potentials at each leaf box.
-    pub potentials: HashMap<MortonKey, Arc<Mutex<Potentials>>>,
+    pub potentials: HashMap<MortonKey, Arc<Mutex<Potentials<U>>>>,
 
     /// The point data at each leaf box.
-    pub points: HashMap<MortonKey, Vec<Point>>,
+    pub points: HashMap<MortonKey, Vec<Point<U>>>,
 
     /// The charge data at each leaf box.
-    pub charges: HashMap<MortonKey, Arc<Vec<f64>>>,
+    pub charges: HashMap<MortonKey, Arc<Vec<U>>>,
 }
 
 /// Type to store data associated with the kernel independent (KiFMM) in.
-pub struct KiFmm<T: Tree, U: Kernel, V: FieldTranslationData<U>> {
+pub struct KiFmm<T, U, V, W>
+where
+    T: Tree,
+    U: Kernel<T = W>,
+    V: FieldTranslationData<U>,
+    W: Scalar + Float + Default,
+{
     /// The expansion order
     pub order: usize,
 
     /// The pseudo-inverse of the dense interaction matrix between the upward check and upward equivalent surfaces.
     /// Store in two parts to avoid propagating error from computing pseudo-inverse
-    pub uc2e_inv_1: C2EType,
-    pub uc2e_inv_2: C2EType,
+    pub uc2e_inv_1: C2EType<W>,
+    pub uc2e_inv_2: C2EType<W>,
 
     /// The pseudo-inverse of the dense interaction matrix between the downward check and downward equivalent surfaces.
     /// Store in two parts to avoid propagating error from computing pseudo-inverse
-    pub dc2e_inv_1: C2EType,
-    pub dc2e_inv_2: C2EType,
+    pub dc2e_inv_1: C2EType<W>,
+    pub dc2e_inv_2: C2EType<W>,
 
     /// The ratio of the inner check surface diamater in comparison to the surface discretising a box.
     pub alpha_inner: f64,
@@ -70,10 +82,10 @@ pub struct KiFmm<T: Tree, U: Kernel, V: FieldTranslationData<U>> {
     pub alpha_outer: f64,
 
     /// The multipole to multipole operator matrices, each index is associated with a child box (in sequential Morton order),
-    pub m2m: Vec<C2EType>,
+    pub m2m: Vec<C2EType<W>>,
 
     /// The local to local operator matrices, each index is associated with a child box (in sequential Morton order).
-    pub l2l: Vec<C2EType>,
+    pub l2l: Vec<C2EType<W>>,
 
     /// The tree (single or multi node) associated with this FMM
     pub tree: T,

--- a/fmm/src/types.rs
+++ b/fmm/src/types.rs
@@ -33,7 +33,7 @@ pub type C2EType<T> = Matrix<T, BaseMatrix<T, VectorContainer<T>, Dynamic>, Dyna
 pub struct FmmData<T, U>
 where
     T: Fmm,
-    U: Scalar + Float + Default,
+    U: Scalar<Real = U> + Float + Default,
 {
     /// The associated FMM object, which implements an FMM interface
     pub fmm: Arc<T>,
@@ -76,10 +76,10 @@ where
     pub dc2e_inv_2: C2EType<W>,
 
     /// The ratio of the inner check surface diamater in comparison to the surface discretising a box.
-    pub alpha_inner: f64,
+    pub alpha_inner: W,
 
     /// The ratio of the outer check surface diamater in comparison to the surface discretising a box.
-    pub alpha_outer: f64,
+    pub alpha_outer: W,
 
     /// The multipole to multipole operator matrices, each index is associated with a child box (in sequential Morton order),
     pub m2m: Vec<C2EType<W>>,
@@ -95,4 +95,12 @@ where
 
     /// The M2L operator matrices, as well as metadata associated with this FMM.
     pub m2l: V,
+}
+
+pub trait SameType {
+    type Other;
+}
+
+impl<T> SameType for T {
+    type Other = T;
 }

--- a/traits/src/field.rs
+++ b/traits/src/field.rs
@@ -1,3 +1,6 @@
+use cauchy::Scalar;
+use num::Float;
+
 use crate::kernel::Kernel;
 
 /// Container for metadata associated with a field translation implementation.
@@ -31,14 +34,17 @@ where
 }
 
 /// Interface for field translations.
-pub trait FieldTranslation {
+pub trait FieldTranslation<T>
+where
+    T: Float + Scalar<Real = T> + Default,
+{
     /// # Warning
     /// This method is only applicable to homogeneous kernels, which are currently
     /// implemented by our software. This method is staged to be deprecated.
     ///
     /// # Arguments
     /// * `level` - The level of the tree at which a field translation is being applied.
-    fn m2l_scale(&self, level: u64) -> f64;
+    fn m2l_scale(&self, level: u64) -> T;
 
     /// Interface for a field translation operation, takes place over each level of an octree.
     ///

--- a/tree/Cargo.toml
+++ b/tree/Cargo.toml
@@ -22,7 +22,7 @@ rand = "0.8.*"
 hyksort = { path = "../hyksort", optional = true }
 bempp-traits = { path = "../traits" }
 rlst = { git = "https://github.com/linalg-rs/rlst.git" }
-num = "0.4.1"
+num = "0.4"
 
 [features]
 mpi = ["dep:mpi", "dep:hyksort"]

--- a/tree/Cargo.toml
+++ b/tree/Cargo.toml
@@ -22,6 +22,7 @@ rand = "0.8.*"
 hyksort = { path = "../hyksort", optional = true }
 bempp-traits = { path = "../traits" }
 rlst = { git = "https://github.com/linalg-rs/rlst.git" }
+num = "0.4.1"
 
 [features]
 mpi = ["dep:mpi", "dep:hyksort"]

--- a/tree/examples/test_adaptive.rs
+++ b/tree/examples/test_adaptive.rs
@@ -18,7 +18,10 @@ use num::traits::Float;
 
 /// Test that the leaves on separate nodes do not overlap.
 #[cfg(feature = "mpi")]
-fn test_no_overlaps<T: Float + Default>(world: &UserCommunicator, tree: &MultiNodeTree<T>) {
+fn test_no_overlaps<T: Float + Default + Scalar<Real = T>>(
+    world: &UserCommunicator,
+    tree: &MultiNodeTree<T>,
+) {
     // Communicate bounds from each process
     let max = tree.leaves.iter().max().unwrap();
     let min = tree.leaves.iter().min().unwrap();

--- a/tree/examples/test_adaptive.rs
+++ b/tree/examples/test_adaptive.rs
@@ -9,11 +9,16 @@ use bempp_tree::implementations::helpers::points_fixture;
 #[cfg(feature = "mpi")]
 use bempp_tree::types::{domain::Domain, morton::MortonKey, multi_node::MultiNodeTree};
 
+use bempp_traits::types::Scalar;
 use rlst::dense::RawAccess;
+
+use rand::distributions::uniform::SampleUniform;
+
+use num::traits::Float;
 
 /// Test that the leaves on separate nodes do not overlap.
 #[cfg(feature = "mpi")]
-fn test_no_overlaps(world: &UserCommunicator, tree: &MultiNodeTree) {
+fn test_no_overlaps<T: Float + Default>(world: &UserCommunicator, tree: &MultiNodeTree<T>) {
     // Communicate bounds from each process
     let max = tree.leaves.iter().max().unwrap();
     let min = tree.leaves.iter().min().unwrap();
@@ -47,9 +52,11 @@ fn test_no_overlaps(world: &UserCommunicator, tree: &MultiNodeTree) {
 
 /// Test that the globally defined domain contains all the points at a given node.
 #[cfg(feature = "mpi")]
-fn test_global_bounds(world: &UserCommunicator) {
+fn test_global_bounds<T: Float + Default + Scalar + Equivalence + SampleUniform>(
+    world: &UserCommunicator,
+) {
     let npoints = 10000;
-    let points = points_fixture(npoints, None, None);
+    let points = points_fixture::<T>(npoints, None, None);
 
     let comm = world.duplicate();
 
@@ -81,7 +88,7 @@ fn main() {
     let n_points = 10000;
     let k = 2;
 
-    let points = points_fixture(n_points, None, None);
+    let points = points_fixture::<f64>(n_points, None, None);
     let global_idxs: Vec<_> = (0..n_points).collect();
 
     let tree = MultiNodeTree::new(
@@ -94,7 +101,7 @@ fn main() {
         &global_idxs,
     );
 
-    test_global_bounds(&comm);
+    test_global_bounds::<f64>(&comm);
     if world.rank() == 0 {
         println!("\t ... test_global_bounds passed on adaptive tree");
     }

--- a/tree/examples/test_let.rs
+++ b/tree/examples/test_let.rs
@@ -1,69 +1,72 @@
-//? mpirun -n {{NPROCESSES}} --features "mpi"
-#![allow(unused_imports)]
+// //? mpirun -n {{NPROCESSES}} --features "mpi"
+// #![allow(unused_imports)]
 
-use bempp_traits::tree::Tree;
-use itertools::Itertools;
+// use bempp_traits::tree::Tree;
+// use itertools::Itertools;
+
+// #[cfg(feature = "mpi")]
+// use mpi::{environment::Universe, traits::*};
+
+// use bempp_tree::implementations::helpers::points_fixture;
+// use rlst::common::traits::accessors::RawAccess;
+
+// #[cfg(feature = "mpi")]
+// use bempp_tree::types::multi_node::MultiNodeTree;
+
+// /// Test that the near field boxes are contained either locally, or in the received boxes
+// /// from the locally essential tree.
+// #[cfg(feature = "mpi")]
+// fn test_near_field(tree: &MultiNodeTree) {
+//     // Create locally essential tree
+//     let locally_essential_tree = tree.create_let();
+
+//     // Test that the tree contains all the data it requires for the near field evaluations
+//     for key in tree.get_all_leaves_set() {
+//         let near_field = key.neighbors();
+
+//         for n in near_field.iter() {
+//             // TODO: work out why this has started failing
+//             // assert!(tree.leaves_set.contains(n) || locally_essential_tree.leaves_set.contains(n));
+//         }
+//     }
+// }
+
+// #[cfg(feature = "mpi")]
+// fn main() {
+//     // Setup an MPI environment
+//     let universe: Universe = mpi::initialize().unwrap();
+//     let world = universe.world();
+//     let comm = world.duplicate();
+
+//     // Setup tree parameters
+//     // let adaptive = false;
+//     let adaptive = false;
+//     let n_crit = Some(50);
+//     let depth = Some(3);
+//     let n_points = 100000;
+//     let k = 2;
+
+//     let points = points_fixture(n_points, None, None);
+//     let global_idxs = (0..n_points).collect_vec();
+
+//     let uniform_tree = MultiNodeTree::new(
+//         &comm,
+//         points.data(),
+//         adaptive,
+//         n_crit,
+//         depth,
+//         k,
+//         &global_idxs,
+//     );
+
+//     test_near_field(&uniform_tree);
+//     if world.rank() == 0 {
+//         println!("\t ... test_near_field passed on uniform tree");
+//     }
+// }
 
 #[cfg(feature = "mpi")]
-use mpi::{environment::Universe, traits::*};
-
-use bempp_tree::implementations::helpers::points_fixture;
-use rlst::common::traits::accessors::RawAccess;
-
-#[cfg(feature = "mpi")]
-use bempp_tree::types::multi_node::MultiNodeTree;
-
-/// Test that the near field boxes are contained either locally, or in the received boxes
-/// from the locally essential tree.
-#[cfg(feature = "mpi")]
-fn test_near_field(tree: &MultiNodeTree) {
-    // Create locally essential tree
-    let locally_essential_tree = tree.create_let();
-
-    // Test that the tree contains all the data it requires for the near field evaluations
-    for key in tree.get_all_leaves_set() {
-        let near_field = key.neighbors();
-
-        for n in near_field.iter() {
-            // TODO: work out why this has started failing
-            // assert!(tree.leaves_set.contains(n) || locally_essential_tree.leaves_set.contains(n));
-        }
-    }
-}
-
-#[cfg(feature = "mpi")]
-fn main() {
-    // Setup an MPI environment
-    let universe: Universe = mpi::initialize().unwrap();
-    let world = universe.world();
-    let comm = world.duplicate();
-
-    // Setup tree parameters
-    // let adaptive = false;
-    let adaptive = false;
-    let n_crit = Some(50);
-    let depth = Some(3);
-    let n_points = 100000;
-    let k = 2;
-
-    let points = points_fixture(n_points, None, None);
-    let global_idxs = (0..n_points).collect_vec();
-
-    let uniform_tree = MultiNodeTree::new(
-        &comm,
-        points.data(),
-        adaptive,
-        n_crit,
-        depth,
-        k,
-        &global_idxs,
-    );
-
-    test_near_field(&uniform_tree);
-    if world.rank() == 0 {
-        println!("\t ... test_near_field passed on uniform tree");
-    }
-}
+fn main() {}
 
 #[cfg(not(feature = "mpi"))]
 fn main() {}

--- a/tree/examples/test_uniform.rs
+++ b/tree/examples/test_uniform.rs
@@ -19,7 +19,10 @@ use num::traits::Float;
 
 /// Test that the leaves on separate nodes do not overlap.
 #[cfg(feature = "mpi")]
-fn test_no_overlaps<T: Float + Default>(world: &UserCommunicator, tree: &MultiNodeTree<T>) {
+fn test_no_overlaps<T: Float + Default + Scalar<Real = T>>(
+    world: &UserCommunicator,
+    tree: &MultiNodeTree<T>,
+) {
     // Communicate bounds from each process
     let max = tree.get_all_leaves_set().iter().max().unwrap();
     let min = tree.get_all_leaves_set().iter().min().unwrap();

--- a/tree/examples/test_uniform.rs
+++ b/tree/examples/test_uniform.rs
@@ -5,6 +5,9 @@
 use mpi::{environment::Universe, topology::UserCommunicator, traits::*};
 
 use bempp_traits::tree::Tree;
+use bempp_traits::types::Scalar;
+
+use rand::distributions::uniform::SampleUniform;
 
 #[cfg(feature = "mpi")]
 use bempp_tree::types::{domain::Domain, morton::MortonKey, multi_node::MultiNodeTree};
@@ -12,9 +15,11 @@ use bempp_tree::types::{domain::Domain, morton::MortonKey, multi_node::MultiNode
 use bempp_tree::implementations::helpers::points_fixture;
 use rlst::dense::RawAccess;
 
+use num::traits::Float;
+
 /// Test that the leaves on separate nodes do not overlap.
 #[cfg(feature = "mpi")]
-fn test_no_overlaps(world: &UserCommunicator, tree: &MultiNodeTree) {
+fn test_no_overlaps<T: Float + Default>(world: &UserCommunicator, tree: &MultiNodeTree<T>) {
     // Communicate bounds from each process
     let max = tree.get_all_leaves_set().iter().max().unwrap();
     let min = tree.get_all_leaves_set().iter().min().unwrap();
@@ -48,9 +53,11 @@ fn test_no_overlaps(world: &UserCommunicator, tree: &MultiNodeTree) {
 
 /// Test that the globally defined domain contains all the points at a given node.
 #[cfg(feature = "mpi")]
-fn test_global_bounds(world: &UserCommunicator) {
+fn test_global_bounds<T: Scalar + Float + Default + Equivalence + SampleUniform>(
+    world: &UserCommunicator,
+) {
     let npoints = 10000;
-    let points = points_fixture(npoints, None, None);
+    let points = points_fixture::<T>(npoints, None, None);
 
     let comm = world.duplicate();
 
@@ -82,13 +89,13 @@ fn main() {
     let n_points = 10000;
 
     // Generate some random test data local to each process
-    let points = points_fixture(n_points, None, None);
+    let points = points_fixture::<f32>(n_points, None, None);
     let global_idxs: Vec<_> = (0..n_points).collect();
 
     // Create a uniform tree
     let tree = MultiNodeTree::new(&comm, points.data(), adaptive, None, depth, k, &global_idxs);
 
-    test_global_bounds(&comm);
+    test_global_bounds::<f32>(&comm);
     if world.rank() == 0 {
         println!("\t ... test_global_bounds passed on uniform tree");
     }

--- a/tree/src/implementations/helpers.rs
+++ b/tree/src/implementations/helpers.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashMap;
 
+use num::Float;
 use rand::prelude::*;
 use rand::SeedableRng;
 
@@ -70,7 +71,7 @@ pub fn points_fixture_col(npoints: usize) -> PointsMat {
 ///
 /// # Arguements:
 /// * `coordinates` - points on the surface of a box.
-pub fn find_corners(coordinates: &[f64]) -> Vec<f64> {
+pub fn find_corners<T: Float>(coordinates: &[T]) -> Vec<T> {
     let n = coordinates.len() / 3;
 
     let xs = coordinates.iter().take(n);
@@ -121,8 +122,11 @@ pub fn find_corners(coordinates: &[f64]) -> Vec<f64> {
 ///
 /// # Arguments
 /// * `order` - the order of expansions used in constructing the surface grid
-pub fn map_corners_to_surface(order: usize) -> (HashMap<usize, usize>, HashMap<usize, usize>) {
-    let (_, surface_multindex) = MortonKey::surface_grid(order);
+pub fn map_corners_to_surface<T>(order: usize) -> (HashMap<usize, usize>, HashMap<usize, usize>)
+where
+    T: Float + std::ops::SubAssign + std::ops::MulAssign,
+{
+    let (_, surface_multindex) = MortonKey::surface_grid::<T>(order);
 
     let nsurf = surface_multindex.len() / 3;
     let ncorners = 8;
@@ -189,10 +193,10 @@ mod test {
     #[test]
     fn test_find_corners() {
         let order = 5;
-        let (grid_1, _) = MortonKey::surface_grid(order);
+        let (grid_1, _) = MortonKey::surface_grid::<f64>(order);
 
         let order = 2;
-        let (grid_2, _) = MortonKey::surface_grid(order);
+        let (grid_2, _) = MortonKey::surface_grid::<f64>(order);
 
         let corners_1 = find_corners(&grid_1);
         let corners_2 = find_corners(&grid_2);

--- a/tree/src/implementations/helpers.rs
+++ b/tree/src/implementations/helpers.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashMap;
 
+use bempp_traits::types::Scalar;
 use num::Float;
 use rand::prelude::*;
 use rand::SeedableRng;
@@ -12,7 +13,7 @@ use rlst::dense::{base_matrix::BaseMatrix, rlst_dynamic_mat, Dynamic, Matrix, Ve
 use crate::types::morton::MortonKey;
 
 /// Alias for an rlst container for point data.
-pub type PointsMat = Matrix<f64, BaseMatrix<f64, VectorContainer<f64>, Dynamic>, Dynamic>;
+pub type PointsMat<T> = Matrix<T, BaseMatrix<T, VectorContainer<T>, Dynamic>, Dynamic>;
 
 /// Points fixture for testing, uniformly samples in each axis from min to max.
 ///
@@ -20,7 +21,11 @@ pub type PointsMat = Matrix<f64, BaseMatrix<f64, VectorContainer<f64>, Dynamic>,
 /// * `npoints` - The number of points to sample.
 /// # `min` - The minumum coordinate value along each axis.
 /// # `max` - The maximum coordinate value along each axis.
-pub fn points_fixture(npoints: usize, min: Option<f64>, max: Option<f64>) -> PointsMat {
+pub fn points_fixture<T: Float + Scalar + rand::distributions::uniform::SampleUniform>(
+    npoints: usize,
+    min: Option<T>,
+    max: Option<T>,
+) -> PointsMat<T> {
     // Generate a set of randomly distributed points
     let mut range = StdRng::seed_from_u64(0);
 
@@ -28,10 +33,10 @@ pub fn points_fixture(npoints: usize, min: Option<f64>, max: Option<f64>) -> Poi
     if let (Some(min), Some(max)) = (min, max) {
         between = rand::distributions::Uniform::from(min..max);
     } else {
-        between = rand::distributions::Uniform::from(0.0_f64..1.0_f64);
+        between = rand::distributions::Uniform::from(T::zero()..T::one());
     }
 
-    let mut points = rlst_dynamic_mat![f64, (npoints, 3)];
+    let mut points = rlst_dynamic_mat![T, (npoints, 3)];
 
     for i in 0..npoints {
         points[[i, 0]] = between.sample(&mut range);
@@ -47,14 +52,16 @@ pub fn points_fixture(npoints: usize, min: Option<f64>, max: Option<f64>) -> Poi
 ///
 /// # Arguments
 /// * `npoints` - The number of points to sample.
-pub fn points_fixture_col(npoints: usize) -> PointsMat {
+pub fn points_fixture_col<T: Float + Scalar + rand::distributions::uniform::SampleUniform>(
+    npoints: usize,
+) -> PointsMat<T> {
     // Generate a set of randomly distributed points
     let mut range = StdRng::seed_from_u64(0);
 
-    let between1 = rand::distributions::Uniform::from(0f64..0.1f64);
-    let between2 = rand::distributions::Uniform::from(0f64..500f64);
+    let between1 = rand::distributions::Uniform::from(T::zero()..T::from(0.1).unwrap());
+    let between2 = rand::distributions::Uniform::from(T::zero()..T::from(500).unwrap());
 
-    let mut points = rlst_dynamic_mat![f64, (npoints, 3)];
+    let mut points = rlst_dynamic_mat![T, (npoints, 3)];
 
     for i in 0..npoints {
         // One axis has a different sampling

--- a/tree/src/implementations/impl_domain.rs
+++ b/tree/src/implementations/impl_domain.rs
@@ -3,7 +3,7 @@ use num::Float;
 
 use crate::types::{domain::Domain, point::PointType};
 
-impl<T: Float> Domain<T> {
+impl<T: Float + Default> Domain<T> {
     /// Compute the domain defined by a set of points on a local node. When defined by a set of points
     /// The domain adds a small threshold such that no points lie on the actual edge of the domain to
     /// ensure correct Morton encoding.
@@ -63,13 +63,17 @@ impl<T: Float> Domain<T> {
 
 #[cfg(test)]
 mod test {
+    use bempp_traits::types::Scalar;
     use rlst::dense::{RawAccess, Shape};
 
     use crate::implementations::helpers::{points_fixture, points_fixture_col, PointsMat};
 
     use super::*;
 
-    fn test_compute_bounds(points: PointsMat) {
+    fn test_compute_bounds<T>(points: PointsMat<T>)
+    where
+        T: Float + Default + Scalar,
+    {
         let domain = Domain::from_local_points(points.data());
 
         // Test that the domain remains cubic
@@ -97,15 +101,15 @@ mod test {
         let npoints = 10000;
 
         // Test points in positive octant only
-        let points = points_fixture(npoints, None, None);
+        let points = points_fixture::<f64>(npoints, None, None);
         test_compute_bounds(points);
 
         // Test points in positive and negative octants
-        let points = points_fixture(npoints, Some(-1.), Some(1.));
+        let points = points_fixture::<f64>(npoints, Some(-1.), Some(1.));
         test_compute_bounds(points);
 
         // Test rectangular distributions of points
-        let points = points_fixture_col(npoints);
+        let points = points_fixture_col::<f64>(npoints);
         test_compute_bounds(points);
     }
 }

--- a/tree/src/implementations/impl_domain.rs
+++ b/tree/src/implementations/impl_domain.rs
@@ -1,16 +1,18 @@
 //! Constructor for a single node Domain.
+use num::Float;
+
 use crate::types::{domain::Domain, point::PointType};
 
-impl Domain {
+impl<T: Float> Domain<T> {
     /// Compute the domain defined by a set of points on a local node. When defined by a set of points
     /// The domain adds a small threshold such that no points lie on the actual edge of the domain to
     /// ensure correct Morton encoding.
     ///
     /// # Arguments
     /// * `points` - A slice of point coordinates, expected in column major order  [x_1, x_2, ... x_N, y_1, y_2, ..., y_N, z_1, z_2, ..., z_N].
-    pub fn from_local_points(points: &[PointType]) -> Domain {
+    pub fn from_local_points(points: &[PointType<T>]) -> Domain<T> {
         // Increase size of bounding box to capture all points
-        let err: f64 = 1e-5;
+        let err = T::from(1e-5).unwrap();
         // TODO: Should be parametrised by dimension
         let dim = 3;
         let npoints = points.len() / dim;
@@ -27,20 +29,21 @@ impl Domain {
         let min_z = z.iter().min_by(|a, b| a.partial_cmp(b).unwrap()).unwrap();
 
         // Find maximum dimension, this will define the size of the boxes in the domain
-        let diameter_x = (max_x - min_x).abs();
-        let diameter_y = (max_y - min_y).abs();
-        let diameter_z = (max_z - min_z).abs();
+        let diameter_x = (*max_x - *min_x).abs();
+        let diameter_y = (*max_y - *min_y).abs();
+        let diameter_z = (*max_z - *min_z).abs();
 
         // Want a cubic box to place everything in
         let diameter = diameter_x.max(diameter_y).max(diameter_z);
+        let two = T::from(2.0).unwrap();
         let diameter = [
-            diameter + 2. * err,
-            diameter + 2. * err,
-            diameter + 2. * err,
+            diameter + two * err,
+            diameter + two * err,
+            diameter + two * err,
         ];
 
         // The origin is defined by the minimum point
-        let origin = [min_x - err, min_y - err, min_z - err];
+        let origin = [*min_x - err, *min_y - err, *min_z - err];
 
         Domain { origin, diameter }
     }
@@ -50,7 +53,7 @@ impl Domain {
     /// # Arguments
     /// * `origin` - The point from which to construct a cuboid domain.
     /// * `diameter` - The diameter along each axis of the domain.
-    pub fn new(origin: &[f64; 3], diameter: &[f64; 3]) -> Self {
+    pub fn new(origin: &[T; 3], diameter: &[T; 3]) -> Self {
         Domain {
             origin: *origin,
             diameter: *diameter,

--- a/tree/src/implementations/impl_morton.rs
+++ b/tree/src/implementations/impl_morton.rs
@@ -232,7 +232,7 @@ fn decode_key(morton: KeyType) -> [KeyType; 3] {
 /// * `point` - The (x, y, z) coordinates of the point to map.
 /// * `level` - The level of the tree at which the point will be mapped.
 /// * `domain` - The computational domain defined by the point set.
-pub fn point_to_anchor<T: Float + ToPrimitive>(
+pub fn point_to_anchor<T: Float + ToPrimitive + Default>(
     point: &[PointType<T>; 3],
     level: KeyType,
     domain: &Domain<T>,
@@ -316,7 +316,11 @@ impl MortonKey {
     /// * `point` - Cartesian coordinate for a given point.
     /// * `domain` - Domain associated with a given tree encoding.
     /// * `level` - level of octree on which to find the encoding.
-    pub fn from_point<T: Float>(point: &[PointType<T>; 3], domain: &Domain<T>, level: u64) -> Self {
+    pub fn from_point<T: Float + Default>(
+        point: &[PointType<T>; 3],
+        domain: &Domain<T>,
+        level: u64,
+    ) -> Self {
         let anchor = point_to_anchor(point, level, domain).unwrap();
         MortonKey::from_anchor(&anchor, level)
     }
@@ -394,7 +398,7 @@ impl MortonKey {
     ///
     /// # Arguments
     /// `domain` - The physical domain with which we calculate the diameter with respect to.
-    pub fn diameter<T: Float>(&self, domain: &Domain<T>) -> [T; 3] {
+    pub fn diameter<T: Float + Default>(&self, domain: &Domain<T>) -> [T; 3] {
         domain
             .diameter
             .map(|x| T::from(0.5).unwrap().powf(T::from(self.level()).unwrap()) * x)
@@ -405,7 +409,7 @@ impl MortonKey {
     ///
     /// # Arguments
     /// * `domain` - The physical domain with which we calculate the centre with respect to.
-    pub fn centre<T: Float>(&self, domain: &Domain<T>) -> [T; 3] {
+    pub fn centre<T: Float + Default>(&self, domain: &Domain<T>) -> [T; 3] {
         let mut result = [T::zero(); 3];
 
         let anchor_coordinate = self.to_coordinates(domain);
@@ -583,7 +587,7 @@ impl MortonKey {
     ///
     /// # Arguments
     /// * `domain` - The domain with which we are calculating with respect to.
-    pub fn to_coordinates<T: Float>(&self, domain: &Domain<T>) -> [PointType<T>; 3] {
+    pub fn to_coordinates<T: Float + Default>(&self, domain: &Domain<T>) -> [PointType<T>; 3] {
         let mut coord: [PointType<T>; 3] = [T::zero(); 3];
 
         for (anchor_value, coord_ref, origin_value, diameter_value) in
@@ -613,7 +617,7 @@ impl MortonKey {
     ///
     /// # Arguments
     /// * `domain` - The domain with which we are calculating with respect to.
-    pub fn box_coordinates<T: Float>(&self, domain: &Domain<T>) -> Vec<T> {
+    pub fn box_coordinates<T: Float + Default>(&self, domain: &Domain<T>) -> Vec<T> {
         let mut serialized = Vec::<T>::with_capacity(24);
         let level = self.level();
         let step = (1 << (DEEPEST_LEVEL - level)) as u64;
@@ -773,7 +777,7 @@ impl MortonKey {
         conv_point_corner_index: usize,
     ) -> (Vec<T>, Vec<usize>)
     where
-        T: Float + std::ops::MulAssign + std::ops::AddAssign + ToPrimitive,
+        T: Float + std::ops::MulAssign + std::ops::AddAssign + ToPrimitive + Default,
     {
         // Number of convolution points along each axis
         let n = 2 * order - 1;
@@ -905,7 +909,12 @@ impl MortonKey {
     /// associated function `surface_grid`.
     /// * `domain` - The physical domain with which Morton Keys are being constructed with respect to.
     /// * `alpha` - The multiplier being used to modify the diameter of the surface grid uniformly along each coordinate axis.
-    pub fn scale_surface<T: Float>(&self, surface: Vec<T>, domain: &Domain<T>, alpha: T) -> Vec<T> {
+    pub fn scale_surface<T: Float + Default>(
+        &self,
+        surface: Vec<T>,
+        domain: &Domain<T>,
+        alpha: T,
+    ) -> Vec<T> {
         let dim = 3;
         // Translate box to specified centre, and scale
         let scaled_diameter = self.diameter(domain);
@@ -937,7 +946,7 @@ impl MortonKey {
     /// * `alpha` - The multiplier being used to modify the diameter of the surface grid uniformly along each coordinate axis.
     pub fn compute_surface<T>(&self, domain: &Domain<T>, order: usize, alpha: T) -> Vec<T>
     where
-        T: Float + std::ops::MulAssign + std::ops::SubAssign,
+        T: Float + std::ops::MulAssign + std::ops::SubAssign + Default,
     {
         let (surface, _) = MortonKey::surface_grid(order);
 

--- a/tree/src/implementations/impl_morton.rs
+++ b/tree/src/implementations/impl_morton.rs
@@ -1,5 +1,6 @@
 //! Implementations of constructors and transformation methods for Morton keys, as well as traits for sorting, and handling containers of Morton keys.
 use itertools::{izip, Itertools};
+use num::{Float, ToPrimitive};
 use std::{
     cmp::Ordering,
     collections::HashSet,
@@ -231,10 +232,10 @@ fn decode_key(morton: KeyType) -> [KeyType; 3] {
 /// * `point` - The (x, y, z) coordinates of the point to map.
 /// * `level` - The level of the tree at which the point will be mapped.
 /// * `domain` - The computational domain defined by the point set.
-pub fn point_to_anchor(
-    point: &[PointType; 3],
+pub fn point_to_anchor<T: Float + ToPrimitive>(
+    point: &[PointType<T>; 3],
     level: KeyType,
-    domain: &Domain,
+    domain: &Domain<T>,
 ) -> Result<[KeyType; 3], Box<dyn Error>> {
     // Check if point is in the domain
 
@@ -248,16 +249,16 @@ pub fn point_to_anchor(
         true => {
             let mut anchor = [KeyType::default(); 3];
 
-            let side_length: Vec<f64> = domain
+            let side_length: Vec<T> = domain
                 .diameter
                 .iter()
-                .map(|d| d / ((1 << level) as f64))
+                .map(|d| *d / T::from(1 << level).unwrap())
                 .collect();
 
             let scaling_factor = 1 << (DEEPEST_LEVEL - level);
 
             for (a, p, o, s) in izip!(&mut anchor, point, &domain.origin, &side_length) {
-                *a = (((p - o) / s).floor()) as KeyType * scaling_factor;
+                *a = (((*p - *o) / *s).floor()).to_u64().unwrap() * scaling_factor;
             }
             Ok(anchor)
         }
@@ -315,7 +316,7 @@ impl MortonKey {
     /// * `point` - Cartesian coordinate for a given point.
     /// * `domain` - Domain associated with a given tree encoding.
     /// * `level` - level of octree on which to find the encoding.
-    pub fn from_point(point: &[PointType; 3], domain: &Domain, level: u64) -> Self {
+    pub fn from_point<T: Float>(point: &[PointType<T>; 3], domain: &Domain<T>, level: u64) -> Self {
         let anchor = point_to_anchor(point, level, domain).unwrap();
         MortonKey::from_anchor(&anchor, level)
     }
@@ -393,10 +394,10 @@ impl MortonKey {
     ///
     /// # Arguments
     /// `domain` - The physical domain with which we calculate the diameter with respect to.
-    pub fn diameter(&self, domain: &Domain) -> [f64; 3] {
+    pub fn diameter<T: Float>(&self, domain: &Domain<T>) -> [T; 3] {
         domain
             .diameter
-            .map(|x| 0.5f64.powf(self.level() as f64) * x)
+            .map(|x| T::from(0.5).unwrap().powf(T::from(self.level()).unwrap()) * x)
     }
 
     /// The physical centre of a box specified by this Morton Key, calculated with respect to
@@ -404,14 +405,15 @@ impl MortonKey {
     ///
     /// # Arguments
     /// * `domain` - The physical domain with which we calculate the centre with respect to.
-    pub fn centre(&self, domain: &Domain) -> [f64; 3] {
-        let mut result = [0f64; 3];
+    pub fn centre<T: Float>(&self, domain: &Domain<T>) -> [T; 3] {
+        let mut result = [T::zero(); 3];
 
         let anchor_coordinate = self.to_coordinates(domain);
         let diameter = self.diameter(domain);
+        let two = T::from(2.0).unwrap();
 
         for (i, (c, d)) in anchor_coordinate.iter().zip(diameter).enumerate() {
-            result[i] = c + d / 2.0;
+            result[i] = *c + d / two;
         }
 
         result
@@ -581,14 +583,14 @@ impl MortonKey {
     ///
     /// # Arguments
     /// * `domain` - The domain with which we are calculating with respect to.
-    pub fn to_coordinates(&self, domain: &Domain) -> [PointType; 3] {
-        let mut coord: [PointType; 3] = [0.0; 3];
+    pub fn to_coordinates<T: Float>(&self, domain: &Domain<T>) -> [PointType<T>; 3] {
+        let mut coord: [PointType<T>; 3] = [T::zero(); 3];
 
         for (anchor_value, coord_ref, origin_value, diameter_value) in
             izip!(self.anchor, &mut coord, &domain.origin, &domain.diameter)
         {
-            *coord_ref = origin_value
-                + diameter_value * (anchor_value as PointType) / (LEVEL_SIZE as PointType);
+            *coord_ref = *origin_value
+                + *diameter_value * T::from(anchor_value).unwrap() / T::from(LEVEL_SIZE).unwrap();
         }
 
         coord
@@ -611,8 +613,8 @@ impl MortonKey {
     ///
     /// # Arguments
     /// * `domain` - The domain with which we are calculating with respect to.
-    pub fn box_coordinates(&self, domain: &Domain) -> Vec<f64> {
-        let mut serialized = Vec::<f64>::with_capacity(24);
+    pub fn box_coordinates<T: Float>(&self, domain: &Domain<T>) -> Vec<T> {
+        let mut serialized = Vec::<T>::with_capacity(24);
         let level = self.level();
         let step = (1 << (DEEPEST_LEVEL - level)) as u64;
 
@@ -632,12 +634,13 @@ impl MortonKey {
         ];
 
         for anchor in anchors.iter() {
-            let mut coord: [PointType; 3] = [0.0; 3];
+            let mut coord = [T::zero(); 3];
             for (&anchor_value, coord_ref, origin_value, diameter_value) in
                 izip!(anchor, &mut coord, &domain.origin, &domain.diameter)
             {
-                *coord_ref = origin_value
-                    + diameter_value * (anchor_value as PointType) / (LEVEL_SIZE as PointType);
+                *coord_ref = *origin_value
+                    + *diameter_value * T::from(anchor_value).unwrap()
+                        / T::from(LEVEL_SIZE).unwrap();
             }
 
             for component in &coord {
@@ -761,47 +764,54 @@ impl MortonKey {
     /// * `alpha` - The multiplier being used to modify the diameter of the surface grid uniformly along each coordinate axis.
     /// * `conv_point` - The corner point on the surface grid against which the surface and  convolution grids are aligned.
     /// * `conv_point_corner_index` - The index of the corner of the surface grid that the conv point lies on.
-    pub fn convolution_grid(
+    pub fn convolution_grid<T>(
         &self,
         order: usize,
-        domain: &Domain,
-        alpha: f64,
-        conv_point_corner: &[f64],
+        domain: &Domain<T>,
+        alpha: T,
+        conv_point_corner: &[T],
         conv_point_corner_index: usize,
-    ) -> (Vec<f64>, Vec<usize>) {
+    ) -> (Vec<T>, Vec<usize>)
+    where
+        T: Float + std::ops::MulAssign + std::ops::AddAssign + ToPrimitive,
+    {
         // Number of convolution points along each axis
         let n = 2 * order - 1;
 
         let dim: usize = 3;
         let ncoeffs = n.pow(dim as u32);
-        let mut grid = vec![0f64; dim * ncoeffs];
+        let mut grid = vec![T::zero(); dim * ncoeffs];
 
         for k in 0..n {
             for j in 0..n {
                 for i in 0..n {
                     let conv_index = i + j * n + k * n * n;
-                    grid[conv_index] = i as f64;
-                    grid[(dim - 2) * ncoeffs + conv_index] = j as f64;
-                    grid[(dim - 1) * ncoeffs + conv_index] = k as f64;
+                    grid[conv_index] = T::from(i).unwrap();
+                    grid[(dim - 2) * ncoeffs + conv_index] = T::from(j).unwrap();
+                    grid[(dim - 1) * ncoeffs + conv_index] = T::from(k).unwrap();
                 }
             }
         }
 
         // Map conv points to indices
-        let conv_idxs = grid.iter().clone().map(|&x| x as usize).collect();
+        let conv_idxs = grid
+            .iter()
+            .clone()
+            .map(|&x| x.to_usize().unwrap())
+            .collect();
 
         let diameter = self
             .diameter(domain)
             .iter()
-            .map(|x| x * alpha)
+            .map(|x| *x * alpha)
             .collect_vec();
 
         // Shift and scale to embed surface grid inside convolution grid
         // Scale
         grid.iter_mut().for_each(|point| {
-            *point *= 1.0 / ((n - 1) as f64); // normalize
+            *point *= T::from(1.0).unwrap() / T::from(n - 1).unwrap(); // normalize
             *point *= diameter[0]; // find diameter
-            *point *= 2.0; // convolution grid is 2x as large
+            *point *= T::from(2.0).unwrap(); // convolution grid is 2x as large
         });
 
         // Shift convolution grid to align with a specified corner of surface grid
@@ -816,7 +826,7 @@ impl MortonKey {
         let diff = conv_point_corner
             .iter()
             .zip(surface_point)
-            .map(|(a, b)| a - b)
+            .map(|(a, b)| *a - b)
             .collect_vec();
 
         for i in 0..dim {
@@ -836,12 +846,15 @@ impl MortonKey {
     ///
     /// # Arguments
     /// * `order` - The expansion order being used in the FMM simulation.
-    pub fn surface_grid(order: usize) -> (Vec<f64>, Vec<usize>) {
+    pub fn surface_grid<T>(order: usize) -> (Vec<T>, Vec<usize>)
+    where
+        T: Float + std::ops::MulAssign + std::ops::SubAssign + ToPrimitive,
+    {
         let dim = 3;
         let n_coeffs = 6 * (order - 1).pow(2) + 2;
 
         // Implicitly in column major order
-        let mut surface: Vec<f64> = vec![0f64; dim * n_coeffs];
+        let mut surface: Vec<T> = vec![T::zero(); dim * n_coeffs];
 
         // Bounds of the surface grid
         let lower = 0;
@@ -857,9 +870,9 @@ impl MortonKey {
                         || (j >= lower && k >= lower && (i == lower || i == upper))
                         || (k >= lower && i >= lower && (j == lower || j == upper))
                     {
-                        surface[idx] = i as f64;
-                        surface[(dim - 2) * n_coeffs + idx] = j as f64;
-                        surface[(dim - 1) * n_coeffs + idx] = k as f64;
+                        surface[idx] = T::from(i).unwrap();
+                        surface[(dim - 2) * n_coeffs + idx] = T::from(j).unwrap();
+                        surface[(dim - 1) * n_coeffs + idx] = T::from(k).unwrap();
                         idx += 1;
                     }
                 }
@@ -867,13 +880,19 @@ impl MortonKey {
         }
 
         // Map surface points to multi-indices
-        let surface_idxs = surface.iter().clone().map(|&x| x as usize).collect();
+        let surface_idxs = surface
+            .iter()
+            .clone()
+            .map(|&x| x.to_usize().unwrap())
+            .collect();
         // Shift and scale surface so that it's centered at the origin and has side length of 1
+        let two = T::from(2.0).unwrap();
+
         surface.iter_mut().for_each(|point| {
-            *point *= 2.0 / (order as f64 - 1.0);
+            *point *= two / (T::from(order).unwrap() - T::one());
         });
 
-        surface.iter_mut().for_each(|point| *point -= 1.0);
+        surface.iter_mut().for_each(|point| *point -= T::one());
 
         (surface, surface_idxs)
     }
@@ -886,23 +905,24 @@ impl MortonKey {
     /// associated function `surface_grid`.
     /// * `domain` - The physical domain with which Morton Keys are being constructed with respect to.
     /// * `alpha` - The multiplier being used to modify the diameter of the surface grid uniformly along each coordinate axis.
-    pub fn scale_surface(&self, surface: Vec<f64>, domain: &Domain, alpha: f64) -> Vec<f64> {
+    pub fn scale_surface<T: Float>(&self, surface: Vec<T>, domain: &Domain<T>, alpha: T) -> Vec<T> {
         let dim = 3;
         // Translate box to specified centre, and scale
         let scaled_diameter = self.diameter(domain);
         let dilated_diameter = scaled_diameter.map(|d| d * alpha);
 
-        let mut scaled_surface = vec![0f64; surface.len()];
+        let mut scaled_surface = vec![T::zero(); surface.len()];
 
         let centre = self.centre(domain);
 
+        let two = T::from(2.0).unwrap();
         let ncoeffs = surface.len() / 3;
         for i in 0..ncoeffs {
-            scaled_surface[i] = (surface[i] * (dilated_diameter[0] / 2.0)) + centre[0];
+            scaled_surface[i] = (surface[i] * (dilated_diameter[0] / two)) + centre[0];
             scaled_surface[(dim - 2) * ncoeffs + i] =
-                (surface[(dim - 2) * ncoeffs + i] * (dilated_diameter[1] / 2.0)) + centre[1];
+                (surface[(dim - 2) * ncoeffs + i] * (dilated_diameter[1] / two)) + centre[1];
             scaled_surface[(dim - 1) * ncoeffs + i] =
-                (surface[(dim - 1) * ncoeffs + i] * (dilated_diameter[2] / 2.0)) + centre[2];
+                (surface[(dim - 1) * ncoeffs + i] * (dilated_diameter[2] / two)) + centre[2];
         }
 
         scaled_surface
@@ -915,10 +935,13 @@ impl MortonKey {
     /// * `domain` - The physical domain with which Morton Keys are being constructed with respect to.
     /// * `order` - The expansion order being used in the FMM simulation.
     /// * `alpha` - The multiplier being used to modify the diameter of the surface grid uniformly along each coordinate axis.
-    pub fn compute_surface(&self, domain: &Domain, order: usize, alpha: f64) -> Vec<f64> {
+    pub fn compute_surface<T>(&self, domain: &Domain<T>, order: usize, alpha: T) -> Vec<T>
+    where
+        T: Float + std::ops::MulAssign + std::ops::SubAssign,
+    {
         let (surface, _) = MortonKey::surface_grid(order);
 
-        self.scale_surface(surface, domain, alpha)
+        self.scale_surface::<T>(surface, domain, alpha)
     }
 }
 
@@ -1233,7 +1256,7 @@ mod test {
 
     #[test]
     fn test_ancestors() {
-        let domain: Domain = Domain {
+        let domain: Domain<f64> = Domain {
             origin: [0., 0., 0.],
             diameter: [1., 1., 1.],
         };
@@ -1288,7 +1311,7 @@ mod test {
     #[test]
     pub fn test_neighbors() {
         let point = [0.5, 0.5, 0.5];
-        let domain: Domain = Domain {
+        let domain: Domain<f64> = Domain {
             diameter: [1., 1., 1.],
             origin: [0., 0., 0.],
         };
@@ -1702,7 +1725,7 @@ mod test {
     #[test]
     fn test_encoding_is_always_absolute() {
         let point = [-0.099999, -0.099999, -0.099999];
-        let domain: Domain = Domain {
+        let domain: Domain<f64> = Domain {
             origin: [-0.1, -0.1, -0.1],
             diameter: [1., 1., 1.],
         };
@@ -1776,7 +1799,7 @@ mod test {
         let surface = key.compute_surface(&domain, order, alpha);
         assert_eq!(surface.len(), ncoeffs * dim);
 
-        let (surface, surface_idxs) = MortonKey::surface_grid(order);
+        let (surface, surface_idxs) = MortonKey::surface_grid::<f64>(order);
         assert_eq!(surface.len(), ncoeffs * dim);
         assert_eq!(surface_idxs.len(), ncoeffs * dim);
 

--- a/tree/src/implementations/impl_multi_node.rs
+++ b/tree/src/implementations/impl_multi_node.rs
@@ -1,4 +1,5 @@
 //! Implementation of constructors for multi node trees from distributed point data.
+use bempp_traits::types::Scalar;
 use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
@@ -25,7 +26,10 @@ use crate::{
     },
 };
 
-impl<T: Float + Default + Equivalence + Debug> MultiNodeTree<T> {
+impl<T> MultiNodeTree<T>
+where
+    T: Float + Default + Equivalence + Debug + Scalar<Real = T>,
+{
     /// Constructor for uniform trees.
     ///
     /// # Arguments
@@ -540,7 +544,10 @@ impl<T: Float + Default + Equivalence + Debug> MultiNodeTree<T> {
     }
 }
 
-impl<T: Float + Default> Tree for MultiNodeTree<T> {
+impl<T> Tree for MultiNodeTree<T>
+where
+    T: Float + Default + Scalar<Real = T>,
+{
     type Domain = Domain<T>;
     type NodeIndex = MortonKey;
     type NodeIndexSlice<'a> = &'a [MortonKey]
@@ -605,7 +612,10 @@ impl<T: Float + Default> Tree for MultiNodeTree<T> {
     }
 }
 
-impl<T: Float + Default + Equivalence> MultiNodeTree<T> {
+impl<T> MultiNodeTree<T>
+where
+    T: Float + Default + Equivalence + Scalar<Real = T>,
+{
     /// Create a locally essential tree (LET) for use in Fast Multipole Methods (FMMs).
     ///
     /// The idea is to communicate the required point and octant data across the distributed tree prior

--- a/tree/src/implementations/impl_point.rs
+++ b/tree/src/implementations/impl_point.rs
@@ -2,36 +2,53 @@
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 
+use bempp_traits::types::Scalar;
+
 use crate::types::point::{Point, Points};
 
-impl<T> PartialEq for Point<T> {
+impl<T> PartialEq for Point<T>
+where
+    T: Scalar<Real = T>,
+{
     fn eq(&self, other: &Self) -> bool {
         self.encoded_key == other.encoded_key
     }
 }
 
-impl<T> Eq for Point<T> {}
+impl<T> Eq for Point<T> where T: Scalar<Real = T> {}
 
-impl<T> Ord for Point<T> {
+impl<T> Ord for Point<T>
+where
+    T: Scalar<Real = T>,
+{
     fn cmp(&self, other: &Self) -> Ordering {
         self.encoded_key.cmp(&other.encoded_key)
     }
 }
 
-impl<T> PartialOrd for Point<T> {
+impl<T> PartialOrd for Point<T>
+where
+    T: Scalar<Real = T>,
+{
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         // less_than(&self.morton, &other.morton)
         Some(self.encoded_key.cmp(&other.encoded_key))
     }
 }
 
-impl<T> Hash for Point<T> {
+impl<T> Hash for Point<T>
+where
+    T: Scalar<Real = T>,
+{
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.encoded_key.hash(state);
     }
 }
 
-impl<T> Points<T> {
+impl<T> Points<T>
+where
+    T: Scalar<Real = T>,
+{
     pub fn new() -> Points<T> {
         Points {
             points: Vec::new(),

--- a/tree/src/implementations/impl_point.rs
+++ b/tree/src/implementations/impl_point.rs
@@ -4,42 +4,42 @@ use std::hash::{Hash, Hasher};
 
 use crate::types::point::{Point, Points};
 
-impl PartialEq for Point {
+impl<T> PartialEq for Point<T> {
     fn eq(&self, other: &Self) -> bool {
         self.encoded_key == other.encoded_key
     }
 }
 
-impl Eq for Point {}
+impl<T> Eq for Point<T> {}
 
-impl Ord for Point {
+impl<T> Ord for Point<T> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.encoded_key.cmp(&other.encoded_key)
     }
 }
 
-impl PartialOrd for Point {
+impl<T> PartialOrd for Point<T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         // less_than(&self.morton, &other.morton)
         Some(self.encoded_key.cmp(&other.encoded_key))
     }
 }
 
-impl Hash for Point {
+impl<T> Hash for Point<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.encoded_key.hash(state);
     }
 }
 
-impl Points {
-    pub fn new() -> Points {
+impl<T> Points<T> {
+    pub fn new() -> Points<T> {
         Points {
             points: Vec::new(),
             index: 0,
         }
     }
 
-    pub fn add(&mut self, item: Point) {
+    pub fn add(&mut self, item: Point<T>) {
         self.points.push(item);
     }
 
@@ -48,29 +48,29 @@ impl Points {
     }
 }
 
-impl Iterator for Points {
-    type Item = Point;
+// impl <T>Iterator for Points<T> {
+//     type Item = Point<T>;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.index >= self.points.len() {
-            return None;
-        }
+//     fn next(&mut self) -> Option<Self::Item> {
+//         if self.index >= self.points.len() {
+//             return None;
+//         }
 
-        self.index += 1;
-        self.points.get(self.index).cloned()
-    }
-}
+//         self.index += 1;
+//         self.points.get(self.index)
+//     }
+// }
 
-impl FromIterator<Point> for Points {
-    fn from_iter<I: IntoIterator<Item = Point>>(iter: I) -> Self {
-        let mut c = Points::new();
+// impl <T> FromIterator<Point<T>> for Points<T> {
+//     fn from_iter<I: IntoIterator<Item = Point<T>>>(iter: I) -> Self {
+//         let mut c = Points::new();
 
-        for i in iter {
-            c.add(i);
-        }
-        c
-    }
-}
+//         for i in iter {
+//             c.add(i);
+//         }
+//         c
+//     }
+// }
 
 #[cfg(test)]
 mod test {
@@ -87,7 +87,7 @@ mod test {
     pub fn points_fixture(npoints: i32) -> Vec<[f64; 3]> {
         let mut range = StdRng::seed_from_u64(0);
         let between = rand::distributions::Uniform::from(0.0..1.0);
-        let mut points: Vec<[PointType; 3]> = Vec::new();
+        let mut points: Vec<[PointType<f64>; 3]> = Vec::new();
 
         for _ in 0..npoints {
             points.push([
@@ -107,7 +107,7 @@ mod test {
             diameter: [1., 1., 1.],
         };
 
-        let mut points: Vec<Point> = points_fixture(1000)
+        let mut points: Vec<Point<f64>> = points_fixture(1000)
             .iter()
             .enumerate()
             .map(|(i, p)| Point {

--- a/tree/src/implementations/impl_point_mpi.rs
+++ b/tree/src/implementations/impl_point_mpi.rs
@@ -3,6 +3,7 @@ use crate::types::{
     morton::{KeyType, MortonKey},
     point::{Point, PointType},
 };
+use bempp_traits::types::Scalar;
 use memoffset::offset_of;
 use mpi::{
     datatype::{Equivalence, UncommittedUserDatatype, UserDatatype},
@@ -10,7 +11,10 @@ use mpi::{
 };
 use num::Float;
 
-unsafe impl<T: Float + Equivalence> Equivalence for Point<T> {
+unsafe impl<T> Equivalence for Point<T>
+where
+    T: Scalar<Real = T> + Float + Equivalence,
+{
     type Out = UserDatatype;
     fn equivalent_datatype() -> Self::Out {
         UserDatatype::structured(

--- a/tree/src/implementations/impl_point_mpi.rs
+++ b/tree/src/implementations/impl_point_mpi.rs
@@ -8,20 +8,21 @@ use mpi::{
     datatype::{Equivalence, UncommittedUserDatatype, UserDatatype},
     Address,
 };
+use num::Float;
 
-unsafe impl <T: Float> Equivalence for Point<T> {
+unsafe impl<T: Float + Equivalence> Equivalence for Point<T> {
     type Out = UserDatatype;
     fn equivalent_datatype() -> Self::Out {
         UserDatatype::structured(
             &[1, 1, 1, 1],
             &[
-                offset_of!(Point, coordinate) as Address,
-                offset_of!(Point, global_idx) as Address,
-                offset_of!(Point, base_key) as Address,
-                offset_of!(Point, encoded_key) as Address,
+                offset_of!(Point<T>, coordinate) as Address,
+                offset_of!(Point<T>, global_idx) as Address,
+                offset_of!(Point<T>, base_key) as Address,
+                offset_of!(Point<T>, encoded_key) as Address,
             ],
             &[
-                UncommittedUserDatatype::contiguous(3, &PointType::equivalent_datatype()).as_ref(),
+                UncommittedUserDatatype::contiguous(3, &T::equivalent_datatype()).as_ref(),
                 UncommittedUserDatatype::contiguous(1, &usize::equivalent_datatype()).as_ref(),
                 UncommittedUserDatatype::structured(
                     &[1, 1],

--- a/tree/src/implementations/impl_point_mpi.rs
+++ b/tree/src/implementations/impl_point_mpi.rs
@@ -9,7 +9,7 @@ use mpi::{
     Address,
 };
 
-unsafe impl Equivalence for Point {
+unsafe impl <T: Float> Equivalence for Point<T> {
     type Out = UserDatatype;
     fn equivalent_datatype() -> Self::Out {
         UserDatatype::structured(

--- a/tree/src/implementations/impl_point_mpi.rs
+++ b/tree/src/implementations/impl_point_mpi.rs
@@ -1,7 +1,7 @@
 //! Implementation of an equivalent MPI type for point data.
 use crate::types::{
     morton::{KeyType, MortonKey},
-    point::{Point, PointType},
+    point::Point,
 };
 use bempp_traits::types::Scalar;
 use memoffset::offset_of;

--- a/tree/src/implementations/impl_single_node.rs
+++ b/tree/src/implementations/impl_single_node.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 use num::Float;
 use std::collections::{HashMap, HashSet};
 
-use bempp_traits::tree::Tree;
+use bempp_traits::{tree::Tree, types::Scalar};
 
 use crate::{
     constants::{DEEPEST_LEVEL, DEFAULT_LEVEL, LEVEL_SIZE, NCRIT, ROOT},
@@ -16,7 +16,10 @@ use crate::{
     },
 };
 
-impl<T: Float + Default> SingleNodeTree<T> {
+impl<T> SingleNodeTree<T>
+where
+    T: Float + Default + Scalar<Real = T>,
+{
     /// Constructor for uniform trees on a single node refined to a user defined depth.
     /// Returns a SingleNodeTree, with the leaves in sorted order.
     ///
@@ -500,7 +503,10 @@ impl<T: Float + Default> SingleNodeTree<T> {
     }
 }
 
-impl<T: Float + Default> Tree for SingleNodeTree<T> {
+impl<T> Tree for SingleNodeTree<T>
+where
+    T: Float + Default + Scalar<Real = T>,
+{
     type Domain = Domain<T>;
     type NodeIndex = MortonKey;
     type NodeIndexSlice<'a> = &'a [MortonKey]

--- a/tree/src/implementations/impl_single_node.rs
+++ b/tree/src/implementations/impl_single_node.rs
@@ -599,7 +599,7 @@ mod test {
         assert!(first == depth);
 
         // Test a column distribution of data
-        let points = points_fixture_col(npoints);
+        let points = points_fixture_col::<f64>(npoints);
         let global_idxs = (0..npoints).collect_vec();
         let tree = SingleNodeTree::new(points.data(), false, None, Some(depth), &global_idxs);
 
@@ -632,7 +632,7 @@ mod test {
     #[test]
     pub fn test_adaptive_tree() {
         let npoints = 10000;
-        let points = points_fixture(npoints, None, None);
+        let points = points_fixture::<f64>(npoints, None, None);
         let global_idxs = (0..npoints).collect_vec();
 
         let adaptive = true;
@@ -677,7 +677,7 @@ mod test {
     #[test]
     pub fn test_no_overlaps() {
         let npoints = 10000;
-        let points = points_fixture(npoints, None, None);
+        let points = points_fixture::<f64>(npoints, None, None);
         let global_idxs = (0..npoints).collect_vec();
         let uniform = SingleNodeTree::new(points.data(), false, Some(150), Some(4), &global_idxs);
         let adaptive = SingleNodeTree::new(points.data(), true, Some(150), None, &global_idxs);
@@ -689,7 +689,7 @@ mod test {
     pub fn test_assign_nodes_to_points() {
         // Generate points in a single octant of the domain
         let npoints = 10;
-        let points = points_fixture(npoints, Some(0.), Some(0.5));
+        let points = points_fixture::<f64>(npoints, Some(0.), Some(0.5));
 
         let domain = Domain {
             origin: [0.0, 0.0, 0.0],
@@ -831,7 +831,7 @@ mod test {
     pub fn test_levels_to_keys() {
         // Uniform tree
         let npoints = 10000;
-        let points = points_fixture(npoints, None, None);
+        let points = points_fixture::<f64>(npoints, None, None);
         let global_idxs = (0..npoints).collect_vec();
         let depth = 3;
         let tree = SingleNodeTree::new(points.data(), false, None, Some(depth), &global_idxs);

--- a/tree/src/types/domain.rs
+++ b/tree/src/types/domain.rs
@@ -5,11 +5,11 @@ use crate::types::point::PointType;
 /// A domain is a box defined aby an origin coordinate and its diameter along all three Cartesian axes.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Default)]
-pub struct Domain {
+pub struct Domain<T> {
     /// The lower left corner of the domain, defined by the point distribution.
-    pub origin: [PointType; 3],
+    pub origin: [PointType<T>; 3],
 
     /// The diameter of the domain along the [x, y, z] axes respectively, defined
     /// by the maximum width of the point distribution along a given axis.
-    pub diameter: [PointType; 3],
+    pub diameter: [PointType<T>; 3],
 }

--- a/tree/src/types/domain.rs
+++ b/tree/src/types/domain.rs
@@ -1,11 +1,15 @@
 //! Data structures for defining the computational domain.
 
 use crate::types::point::PointType;
+use num::traits::Float;
 
 /// A domain is a box defined aby an origin coordinate and its diameter along all three Cartesian axes.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Default)]
-pub struct Domain<T> {
+pub struct Domain<T>
+where
+    T: Float + Default,
+{
     /// The lower left corner of the domain, defined by the point distribution.
     pub origin: [PointType<T>; 3],
 

--- a/tree/src/types/multi_node.rs
+++ b/tree/src/types/multi_node.rs
@@ -1,9 +1,10 @@
 //! Data structures to create distributed octrees with MPI.
+use bempp_traits::types::Scalar;
 use mpi::topology::UserCommunicator;
 
 use std::collections::{HashMap, HashSet};
 
-use num::traits::Float;
+use num::traits::{real::Real, Float};
 
 use crate::types::{
     domain::Domain,
@@ -14,7 +15,7 @@ use crate::types::{
 /// Concrete distributed multi-node tree.
 pub struct MultiNodeTree<T>
 where
-    T: Default + Float,
+    T: Default + Float + Scalar<Real = T>,
 {
     /// Global communicator for this Tree
     pub world: UserCommunicator,

--- a/tree/src/types/multi_node.rs
+++ b/tree/src/types/multi_node.rs
@@ -4,7 +4,7 @@ use mpi::topology::UserCommunicator;
 
 use std::collections::{HashMap, HashSet};
 
-use num::traits::{real::Real, Float};
+use num::traits::Float;
 
 use crate::types::{
     domain::Domain,

--- a/tree/src/types/multi_node.rs
+++ b/tree/src/types/multi_node.rs
@@ -10,7 +10,7 @@ use crate::types::{
 };
 
 /// Concrete distributed multi-node tree.
-pub struct MultiNodeTree {
+pub struct MultiNodeTree<T> {
     /// Global communicator for this Tree
     pub world: UserCommunicator,
 
@@ -18,10 +18,10 @@ pub struct MultiNodeTree {
     pub depth: u64,
 
     /// Domain spanned by the points.
-    pub domain: Domain,
+    pub domain: Domain<T>,
 
     ///  A vector of Cartesian points.
-    pub points: Points,
+    pub points: Points<T>,
 
     /// The leaves that span the tree.
     pub leaves: MortonKeys,

--- a/tree/src/types/multi_node.rs
+++ b/tree/src/types/multi_node.rs
@@ -3,6 +3,8 @@ use mpi::topology::UserCommunicator;
 
 use std::collections::{HashMap, HashSet};
 
+use num::traits::Float;
+
 use crate::types::{
     domain::Domain,
     morton::{KeyType, MortonKey, MortonKeys},
@@ -10,7 +12,10 @@ use crate::types::{
 };
 
 /// Concrete distributed multi-node tree.
-pub struct MultiNodeTree<T> {
+pub struct MultiNodeTree<T>
+where
+    T: Default + Float,
+{
     /// Global communicator for this Tree
     pub world: UserCommunicator,
 

--- a/tree/src/types/point.rs
+++ b/tree/src/types/point.rs
@@ -1,4 +1,6 @@
 //! Data structures for Cartesian Points in 3D.
+use bempp_traits::types::Scalar;
+
 use crate::types::morton::MortonKey;
 
 pub type PointType<T> = T;
@@ -9,7 +11,10 @@ pub type PointType<T> = T;
 /// specifiying its encoding at a given level of discretization. Points also have associated data
 #[repr(C)]
 #[derive(Clone, Debug, Default, Copy)]
-pub struct Point<T> {
+pub struct Point<T>
+where
+    T: Scalar<Real = T>,
+{
     /// Physical coordinate in Cartesian space.
     pub coordinate: [PointType<T>; 3],
 
@@ -26,7 +31,10 @@ pub struct Point<T> {
 /// Vector of **Points**.
 /// Container of **Points**.
 #[derive(Clone, Debug, Default)]
-pub struct Points<T> {
+pub struct Points<T>
+where
+    T: Scalar<Real = T>,
+{
     /// A vector of Points
     pub points: Vec<Point<T>>,
 

--- a/tree/src/types/point.rs
+++ b/tree/src/types/point.rs
@@ -1,7 +1,7 @@
 //! Data structures for Cartesian Points in 3D.
 use crate::types::morton::MortonKey;
 
-pub type PointType = f64;
+pub type PointType<T> = T;
 
 /// A 3D cartesian point, described by coordinate, a unique global index, and the Morton Key for
 /// the octree node in which it lies. Each Point as an associated 'base key', which is its matching
@@ -9,9 +9,9 @@ pub type PointType = f64;
 /// specifiying its encoding at a given level of discretization. Points also have associated data
 #[repr(C)]
 #[derive(Clone, Debug, Default, Copy)]
-pub struct Point {
+pub struct Point<T> {
     /// Physical coordinate in Cartesian space.
-    pub coordinate: [PointType; 3],
+    pub coordinate: [PointType<T>; 3],
 
     /// Global unique index.
     pub global_idx: usize,
@@ -26,9 +26,9 @@ pub struct Point {
 /// Vector of **Points**.
 /// Container of **Points**.
 #[derive(Clone, Debug, Default)]
-pub struct Points {
+pub struct Points<T> {
     /// A vector of Points
-    pub points: Vec<Point>,
+    pub points: Vec<Point<T>>,
 
     /// index for implementing the Iterator trait.
     pub index: usize,

--- a/tree/src/types/single_node.rs
+++ b/tree/src/types/single_node.rs
@@ -1,6 +1,8 @@
 //! Data Structures to create octrees on a single node.
 use std::collections::{HashMap, HashSet};
 
+use num::Float;
+
 use crate::types::{
     domain::Domain,
     morton::{MortonKey, MortonKeys},
@@ -9,15 +11,15 @@ use crate::types::{
 
 /// Local Trees (non-distributed).
 #[derive(Debug)]
-pub struct SingleNodeTree {
+pub struct SingleNodeTree<T: Float> {
     /// Depth of a tree.
     pub depth: u64,
 
     /// Domain spanned by the points.
-    pub domain: Domain,
+    pub domain: Domain<T>,
 
     ///  All Points.
-    pub points: Points,
+    pub points: Points<T>,
 
     /// The leaves that span the tree, and associated Point data.
     pub leaves: MortonKeys,

--- a/tree/src/types/single_node.rs
+++ b/tree/src/types/single_node.rs
@@ -1,6 +1,7 @@
 //! Data Structures to create octrees on a single node.
 use std::collections::{HashMap, HashSet};
 
+use bempp_traits::types::Scalar;
 use num::Float;
 
 use crate::types::{
@@ -13,7 +14,7 @@ use crate::types::{
 #[derive(Debug)]
 pub struct SingleNodeTree<T>
 where
-    T: Float + Default,
+    T: Float + Default + Scalar<Real = T>,
 {
     /// Depth of a tree.
     pub depth: u64,

--- a/tree/src/types/single_node.rs
+++ b/tree/src/types/single_node.rs
@@ -11,7 +11,7 @@ use crate::types::{
 
 /// Local Trees (non-distributed).
 #[derive(Debug)]
-pub struct SingleNodeTree<T: Float> {
+pub struct SingleNodeTree<T: Float + Default> {
     /// Depth of a tree.
     pub depth: u64,
 

--- a/tree/src/types/single_node.rs
+++ b/tree/src/types/single_node.rs
@@ -11,7 +11,10 @@ use crate::types::{
 
 /// Local Trees (non-distributed).
 #[derive(Debug)]
-pub struct SingleNodeTree<T: Float + Default> {
+pub struct SingleNodeTree<T>
+where
+    T: Float + Default,
+{
     /// Depth of a tree.
     pub depth: u64,
 


### PR DESCRIPTION
This PR is to make the FMM (and therefore the Tree and Field translations) generic over 32/64 bit input types.  

This is preliminary work before an upgrade of the interface to a builder pattern, as a user should be able to specify the level of precision they desire.