### PR TITLE
FIX: Re-Add parallel iterators for SVD based M2L kernels

### DIFF
--- a/fmm/src/field_translation/source_to_target.rs
+++ b/fmm/src/field_translation/source_to_target.rs
@@ -651,8 +651,9 @@ pub mod uniform {
                     for (result_idx, &save_idx) in displacements.iter().enumerate() {
                         if save_idx > -1 {
                             let save_idx = save_idx as usize;
+                            let local_lock = level_locals[save_idx].lock().unwrap();
+
                             for charge_vec_idx in 0..self.ncharge_vectors {
-                                let local_lock = level_locals[save_idx].lock().unwrap();
                                 let local_send_ptr = local_lock[charge_vec_idx];
                                 let local_ptr = local_send_ptr.raw;
 

--- a/fmm/src/field_translation/source_to_target.rs
+++ b/fmm/src/field_translation/source_to_target.rs
@@ -464,7 +464,7 @@ pub mod uniform {
 
             let level_locals = self.level_locals[level as usize]
                 .iter()
-                .map(|l| Mutex::new(l))
+                .map(Mutex::new)
                 .collect_vec();
 
             (0..316).into_par_iter().for_each(|c_idx| {
@@ -619,7 +619,7 @@ pub mod uniform {
 
                 let level_locals = self.level_locals[level as usize]
                     .iter()
-                    .map(|inner_vec| Mutex::new(inner_vec))
+                    .map(Mutex::new)
                     .collect_vec();
 
                 (0..316).into_par_iter().for_each(|c_idx| {
@@ -652,8 +652,6 @@ pub mod uniform {
                         if save_idx > -1 {
                             let save_idx = save_idx as usize;
                             for charge_vec_idx in 0..self.ncharge_vectors {
-                                // let local_ptr =
-                                //     self.level_locals[level as usize][save_idx][charge_vec_idx].raw;
                                 let local_lock = level_locals[save_idx].lock().unwrap();
                                 let local_send_ptr = local_lock[charge_vec_idx];
                                 let local_ptr = local_send_ptr.raw;

--- a/fmm/src/field_translation/source_to_target.rs
+++ b/fmm/src/field_translation/source_to_target.rs
@@ -35,6 +35,8 @@ use super::hadamard::matmul8x8;
 
 /// Field translations defined on uniformly refined trees.
 pub mod uniform {
+    use std::sync::Mutex;
+
     use rlst_dense::rlst_array_from_slice2;
 
     use super::*;
@@ -460,7 +462,9 @@ pub mod uniform {
                 .iter_mut()
                 .for_each(|d| *d *= self.fmm.kernel.scale(level) * self.m2l_scale(level));
 
-            (0..316).for_each(|c_idx| {
+            let level_locals = self.level_locals[level as usize].iter().map(|l| Mutex::new(l)).collect_vec();
+
+            (0..316).into_par_iter().for_each(|c_idx| {
                 let top_left = [0, c_idx * self.fmm.m2l.k];
                 let c_sub = self
                     .fmm
@@ -489,7 +493,8 @@ pub mod uniform {
                 for (result_idx, &save_idx) in displacements.iter().enumerate() {
                     if save_idx > -1 {
                         let save_idx = save_idx as usize;
-                        let local_ptr = self.level_locals[level as usize][save_idx].raw;
+                        let local_lock = level_locals[save_idx].lock().unwrap();
+                        let local_ptr = local_lock.raw;
                         let local = unsafe { std::slice::from_raw_parts_mut(local_ptr, ncoeffs) };
 
                         let res = &locals.data()[result_idx * ncoeffs..(result_idx + 1) * ncoeffs];
@@ -609,7 +614,7 @@ pub mod uniform {
                     .iter_mut()
                     .for_each(|d| *d *= self.fmm.kernel.scale(level) * self.m2l_scale(level));
 
-                (0..316).for_each(|c_idx| {
+                (0..316).into_par_iter().for_each(|c_idx| {
                     let top_left = [0, c_idx * self.fmm.m2l.k];
                     let c_sub = self
                         .fmm
@@ -635,12 +640,23 @@ pub mod uniform {
 
                     let displacements = &all_displacements[c_idx];
 
+                    let level_locals = self.level_locals[level as usize]
+                        .iter()
+                        .map(|inner_vec|
+                            inner_vec
+                            .into_iter()
+                            .map(|ptr| Mutex::new(ptr.clone())).collect_vec()
+                            ).collect_vec();
+
                     for (result_idx, &save_idx) in displacements.iter().enumerate() {
                         if save_idx > -1 {
                             let save_idx = save_idx as usize;
                             for charge_vec_idx in 0..self.ncharge_vectors {
-                                let local_ptr =
-                                    self.level_locals[level as usize][save_idx][charge_vec_idx].raw;
+                                // let local_ptr =
+                                //     self.level_locals[level as usize][save_idx][charge_vec_idx].raw;
+                                let local_lock = level_locals[save_idx][charge_vec_idx].lock().unwrap();
+                                let local_ptr = local_lock.raw;
+
                                 let local = unsafe {
                                     std::slice::from_raw_parts_mut(local_ptr, self.ncoeffs)
                                 };

--- a/fmm/src/fmm.rs
+++ b/fmm/src/fmm.rs
@@ -818,7 +818,7 @@ mod test {
                 test_idx_vec.push(idx);
             }
         }
-        let leaf = &datatree.fmm.tree().get_all_leaves().unwrap()[test_idx_vec[3]];
+        let leaf = &datatree.fmm.tree().get_all_leaves().unwrap()[test_idx_vec[0]];
 
         let leaf_idx = datatree.fmm.tree().get_leaf_index(leaf).unwrap();
 
@@ -907,7 +907,7 @@ mod test {
                 test_idx_vec.push(idx);
             }
         }
-        let leaf = &datatree.fmm.tree().get_all_leaves().unwrap()[test_idx_vec[3]];
+        let leaf = &datatree.fmm.tree().get_all_leaves().unwrap()[test_idx_vec[0]];
 
         let leaf_idx = datatree.fmm.tree().get_leaf_index(leaf).unwrap();
 
@@ -950,7 +950,7 @@ mod test {
             "rel_error = {rel_error} = {abs_error} / {}",
             direct.iter().sum::<f64>()
         );
-        assert!(rel_error <= 1e-3);
+        assert!(rel_error <= 1e-5);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1169,7 +1169,7 @@ mod test {
                 test_idx_vec.push(idx);
             }
         }
-        let leaf = &datatree.fmm.tree().get_all_leaves().unwrap()[test_idx_vec[3]];
+        let leaf = &datatree.fmm.tree().get_all_leaves().unwrap()[test_idx_vec[0]];
 
         let &leaf_idx = datatree.fmm.tree().get_leaf_index(leaf).unwrap();
         let (l, r) = datatree.charge_index_pointer[leaf_idx];


### PR DESCRIPTION
- Simply wrapped thread unsafe pointers in mutexes, performance not significantly impacted as it's rare that multiple threads are writing to same memory locations in this kernel.

Addresses #151 and #148