### PR TITLE
Fix rlst to commit before blis-src removed

### DIFF
--- a/bem/Cargo.toml
+++ b/bem/Cargo.toml
@@ -35,10 +35,9 @@ itertools = "0.10"
 mpi = { version = "0.6.*", optional = true }
 num = "0.4"
 rayon = "1.7"
-rlst = { git = "https://github.com/linalg-rs/rlst.git" }
-rlst-blis-src = { git = "https://github.com/linalg-rs/rlst.git" }
-rlst-dense = { git = "https://github.com/linalg-rs/rlst.git" }
-rlst-sparse = { git = "https://github.com/linalg-rs/rlst.git" }
+rlst = { git = "https://github.com/linalg-rs/rlst.git", rev="d0cf6cb" }
+rlst-dense = { git = "https://github.com/linalg-rs/rlst.git", rev="d0cf6cb" }
+rlst-sparse = { git = "https://github.com/linalg-rs/rlst.git", rev="d0cf6cb" }
 rand = "0.8.5"
 
 [dev-dependencies]

--- a/element/Cargo.toml
+++ b/element/Cargo.toml
@@ -26,9 +26,9 @@ bempp-quadrature = { path = "../quadrature" }
 paste = "1.*"
 libc = "0.2"
 approx = "0.5"
-rlst = { git = "https://github.com/linalg-rs/rlst.git" }
-rlst-blis-src = { git = "https://github.com/linalg-rs/rlst.git" }
-rlst-dense = { git = "https://github.com/linalg-rs/rlst.git" }
+rlst = { git = "https://github.com/linalg-rs/rlst.git", rev="d0cf6cb" }
+rlst-blis-src = { git = "https://github.com/linalg-rs/rlst.git", rev="d0cf6cb" }
+rlst-dense = { git = "https://github.com/linalg-rs/rlst.git", rev="d0cf6cb" }
 num = "0.4"
 
 [package.metadata.docs.rs]

--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -28,9 +28,9 @@ bempp-kernel = { path = "../kernel" }
 bempp-tools = { path = "../tools" }
 itertools = "0.10"
 num = "0.4"
-rlst = { git = "https://github.com/linalg-rs/rlst.git" }
-rlst-dense = { git = "https://github.com/linalg-rs/rlst.git" }
-rlst-blis = { git = "https://github.com/linalg-rs/rlst.git" }
+rlst = { git = "https://github.com/linalg-rs/rlst.git", rev="d0cf6cb" }
+rlst-dense = { git = "https://github.com/linalg-rs/rlst.git", rev="d0cf6cb" }
+rlst-blis = { git = "https://github.com/linalg-rs/rlst.git", rev="d0cf6cb" }
 fftw = {git = "https://github.com/skailasa/fftw.git" }
 cauchy = "0.4.*"
 approx = "0.5"

--- a/fmm/Cargo.toml
+++ b/fmm/Cargo.toml
@@ -34,8 +34,8 @@ rand = "0.8.*"
 float-cmp = "0.9.0"
 num_cpus = "1"
 num = "0.4"
-rlst-dense = { git = "https://github.com/linalg-rs/rlst.git" }
-rlst-blis = { git = "https://github.com/linalg-rs/rlst.git" }
+rlst-dense = { git = "https://github.com/linalg-rs/rlst.git", rev="d0cf6cb" }
+rlst-blis = { git = "https://github.com/linalg-rs/rlst.git", rev="d0cf6cb" }
 fftw = { git = "https://github.com/skailasa/fftw.git" }
 rayon = "1.7"
 

--- a/grid/Cargo.toml
+++ b/grid/Cargo.toml
@@ -29,8 +29,8 @@ num = "0.4"
 log = "0.4"
 itertools = "0.10"
 mpi = { version = "0.6.*", optional = true }
-rlst-proc-macro = { git = "https://github.com/linalg-rs/rlst.git" }
-rlst-dense = { git = "https://github.com/linalg-rs/rlst.git" }
+rlst-proc-macro = { git = "https://github.com/linalg-rs/rlst.git", rev="d0cf6cb" }
+rlst-dense = { git = "https://github.com/linalg-rs/rlst.git", rev="d0cf6cb" }
 
 [package.metadata.docs.rs]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -28,8 +28,8 @@ approx = { version = "0.5", features = ["num-complex"] }
 rayon = "1.7"
 num = "0.4"
 num_cpus = "1"
-rlst-dense = { git = "https://github.com/linalg-rs/rlst.git" }
-rlst = { git = "https://github.com/linalg-rs/rlst.git" }
+rlst-dense = { git = "https://github.com/linalg-rs/rlst.git", rev="d0cf6cb" }
+rlst = { git = "https://github.com/linalg-rs/rlst.git", rev="d0cf6cb" }
 rand = "0.8.5"
 
 [package.metadata.docs.rs]

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["lib", "cdylib"]
 cauchy="0.4.*"
 thiserror="1.*"
 num = "0.4"
-rlst-dense = { git = "https://github.com/linalg-rs/rlst.git" }
+rlst-dense = { git = "https://github.com/linalg-rs/rlst.git", rev="d0cf6cb" }
 
 [package.metadata.docs.rs]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]

--- a/tree/Cargo.toml
+++ b/tree/Cargo.toml
@@ -22,8 +22,8 @@ memoffset = "0.6"
 rand = "0.8.*"
 hyksort = { path = "../hyksort", optional = true }
 bempp-traits = { path = "../traits" }
-rlst = { git = "https://github.com/linalg-rs/rlst.git" }
-rlst-dense = { git = "https://github.com/linalg-rs/rlst.git" }
+rlst = { git = "https://github.com/linalg-rs/rlst.git", rev="d0cf6cb" }
+rlst-dense = { git = "https://github.com/linalg-rs/rlst.git", rev="d0cf6cb" }
 num = "0.4"
 cauchy = "0.4.0"
 


### PR DESCRIPTION
This is needed until some updates are made, then should be reverted