### PR TITLE
add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+cff-version: 1.2.0
+message: Please cite the following works when using this software.
+type: software
+authors:
+  - family-names: Betcke
+    given-names: Timo
+    orcid: https://orcid.org/0000-0002-3323-2110
+  - family-names: Scroggs
+    given-names: Matthew
+    orcid: https://orcid.org/0000-0002-4658-2443
+doi: 10.21105/joss.02879
+identifiers:
+  - type: doi
+    value: 10.21105/joss.02879
+  - type: url
+    value: http://dx.doi.org/10.21105/joss.02879
+  - type: other
+    value: urn:issn:2475-9066
+title: 'Bempp-cl: A fast Python based just-in-time compiling boundary element library.'
+url: http://dx.doi.org/10.21105/joss.02879


### PR DESCRIPTION
This adds the joss publication as a CITATION.cff file such that it can be discovered by tools such as [`crate2bib`](https://github.com/jonaspleyer/crate2bib).